### PR TITLE
This took significantly more effort than I thought it would.

### DIFF
--- a/src/main/java/alarmmonitoringsystem/AlarmMonitoringClient.java
+++ b/src/main/java/alarmmonitoringsystem/AlarmMonitoringClient.java
@@ -13,15 +13,16 @@ import networkmanagementsystem.NetworkManagementSystemIf;
  */
 public class AlarmMonitoringClient {
 	
-	static final String MENU = "\nPlease enter the number corresponding to the option you would like to choose:\n"
+	private static final String MENU = "\nPlease enter the number corresponding to the option you would like to choose:\n"
 			+ "0.	Exit Program\n"
 			+ "1.	Get Network Alarms\n"
 			+ "2.	Acknowledge Alarm on Radio Unit";
 
-	static final Pattern IP_PATTERN = Pattern.compile("^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\."
+	private static final Pattern IP_PATTERN = Pattern.compile("^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\."
 			+ "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\."
 			+ "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\."
 			+ "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$");
+	private static final String INPUT_PROMPT = "> ";
 
 	/**
 	 * Entry-point into the application.
@@ -31,12 +32,18 @@ public class AlarmMonitoringClient {
 	public static void main(String[] args) {
 		String networkMgmtId = NetworkManagementClient.NETWORK_MGMT_ID;
 		
-		AlarmMonitoringSystem alMonitoringSys;
+		AlarmMonitoringSystemIf alMonitoringSys;
 		
 		try {
 			NetworkManagementSystemIf networkMgmtSys = (NetworkManagementSystemIf) Naming.lookup(networkMgmtId);
 			alMonitoringSys = new AlarmMonitoringSystem(networkMgmtSys);
-			
+
+			System.out.println(
+					"#############################################################\n" +
+					"##                 ALARM MONITORING CLIENT                 ##\n" +
+					"##                        TEAM A.2                         ##\n" +
+					"##               ERICSSON OOP: SUMMER 2021                 ##\n" +
+					"#############################################################\n");
 			System.out.println("Welcome!");
 			Scanner input = new Scanner(System.in);
 			String option = "-1";
@@ -44,32 +51,37 @@ public class AlarmMonitoringClient {
 
 			while(!option.equals("0"))
 			{
-				System.out.println(MENU);
-				option = input.next();
+				System.out.print(MENU);
+				System.out.print(INPUT_PROMPT);
+				option = input.next().trim();
 				
 				switch (option) {
 				case "0":
-					System.out.println("Goodbye!\n");
+					input.close();
+					System.out.println("\nGoodbye!");
 					break;
 				case "1":
 					alMonitoringSys.getNetAlarms();
+					returnToMenu();
 					break;
 				case "2":
 					ip = getIpAddress(input);
 					alMonitoringSys.acknowledgeAlarmOnRu(ip);
+					returnToMenu();
 					break;
 				default:
-					System.out.println("Unsupported option, please try again!!");
+					System.out.println("Unsupported option, please try again!");
 					break;
 				}
 			}
 		}
 		catch (Exception e)
 		{
-			System.out.println("Error connecting to network management system");
+			System.out.println("Error connecting to network management system.");
 			e.printStackTrace();
 			System.exit(0);
 		}
+		System.exit(0);
 	}
 
 	/**
@@ -81,17 +93,31 @@ public class AlarmMonitoringClient {
 	 */
 	private static String getIpAddress(Scanner input) {
 		String ip;
+		input.nextLine();
 		do {
-			System.out.println("Please enter the IP address of the Radio Unit you want to operate on:");
-			ip = input.next();
-			if (IP_PATTERN.matcher(ip).matches()) {
-				System.out.println("IP address is fine.");
+			System.out.print("\nPlease enter the IP address of the Radio Unit you want to operate on.\n"
+					+ "Enter 'Back' to go back to the menu\n");
+			System.out.print(INPUT_PROMPT);
+			ip = input.nextLine().trim();
+			if (ip.equalsIgnoreCase("BACK")) {
 				break;
 			}
-			System.out.println("Invalid IP address format, please try again: " + ip);
+			if (IP_PATTERN.matcher(ip).matches()) {
+				break;
+			}
+			System.out.println("Input is not a valid IP address: " + ip + "\nPlease try again.");
 		} while (true);
 
 		return ip;
 	}
 
+	private static void returnToMenu() {
+		System.out.print("Please press the Enter key to return to the main menu.");
+		try
+		{
+			System.in.read();
+		}
+		catch(Exception e)
+		{}
+	}
 }

--- a/src/main/java/alarmmonitoringsystem/AlarmMonitoringSystem.java
+++ b/src/main/java/alarmmonitoringsystem/AlarmMonitoringSystem.java
@@ -1,44 +1,37 @@
 package alarmmonitoringsystem;
 
-import java.rmi.RemoteException;
-
 import networkmanagementsystem.NetworkManagementSystemIf;
+
+import java.rmi.RemoteException;
 
 /**
  * @author edavleu
- *
  */
-public class AlarmMonitoringSystem {
+public class AlarmMonitoringSystem implements AlarmMonitoringSystemIf {
 
-	final NetworkManagementSystemIf networkMgmt;
-	
-	public AlarmMonitoringSystem(NetworkManagementSystemIf net)
-	{
-		this.networkMgmt = net;
-	}
-	
-	public void getNetAlarms()
-	{
-		try {
-			System.out.println(this.networkMgmt.getNetworkAlarms());
-		} catch (RemoteException e) {
-			e.printStackTrace();
-		}
-	}
-	
-	public void acknowledgeAlarmOnRu(String ipAddress)
-	{
-		try {
-			if (this.networkMgmt.acknowledgeAlarm(ipAddress))
-			{
-				System.out.println("Successfully acknowledged alarm on " + ipAddress);
-			}
-			else
-			{
-				System.out.println("Failed to acknowledge alarm on " + ipAddress);
-			}
-		} catch (RemoteException e) {
-			e.printStackTrace();
-		}
-	}
+    final NetworkManagementSystemIf networkMgmt;
+
+    public AlarmMonitoringSystem(NetworkManagementSystemIf net) {
+        this.networkMgmt = net;
+    }
+
+    public void getNetAlarms() {
+        try {
+            networkMgmt.getNetworkAlarms();
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void acknowledgeAlarmOnRu(String ipAddress) {
+        try {
+            if (this.networkMgmt.acknowledgeAlarm(ipAddress)) {
+                System.out.printf("Successfully acknowledged alarm on the Radio Unit with the IP address \"%s\"", ipAddress);
+            } else {
+                System.out.printf("Failed to acknowledge alarm on the Radio Unit with the IP address \"%s\"", ipAddress);
+            }
+        } catch (RemoteException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/alarmmonitoringsystem/AlarmMonitoringSystemIf.java
+++ b/src/main/java/alarmmonitoringsystem/AlarmMonitoringSystemIf.java
@@ -1,0 +1,10 @@
+package alarmmonitoringsystem;
+
+/**
+ * @author ebreojh
+ */
+interface AlarmMonitoringSystemIf {
+    void getNetAlarms();
+
+    void acknowledgeAlarmOnRu(String ipAddress);
+}

--- a/src/main/java/mediator/Mediator.java
+++ b/src/main/java/mediator/Mediator.java
@@ -181,7 +181,7 @@ public class Mediator implements PropertyChangeListener, MediatorIf {
         } else if (param instanceof FrequencyBand) {
             List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByBand((FrequencyBand) param);
             if (radioUnits.size() == 0) {
-                System.out.printf("No Radio Units with the state \"%s\" exist in the system.\n", param);
+                System.out.printf("No Radio Units with the frequency band \"%s\" exist in the system.\n", param);
             } else {
                 radioUnits.forEach(ru -> System.out.println(ru + "\n"));
             }

--- a/src/main/java/mediator/Mediator.java
+++ b/src/main/java/mediator/Mediator.java
@@ -2,15 +2,17 @@ package mediator;
 
 import carriermanagementsystem.CarrierManagementSystemDirector;
 import common.*;
-import radiounit.ManagedRadioUnit;
 import radiounit.AbstractManagedRadioUnitRegistry;
+import radiounit.ManagedRadioUnit;
 import radiounit.ManagedRadioUnitRegistry;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * The Mediator class is responsible for handling control/communication
@@ -30,409 +32,412 @@ import java.util.stream.Collectors;
  * @author ebreojh
  */
 public class Mediator implements PropertyChangeListener, MediatorIf {
-	private static volatile Mediator UNIQUE_INSTANCE;
-	private final PropertyChangeSupport support;
-	private final CarrierManagementSystemDirector carrierManagement;
-	private final AbstractManagedRadioUnitRegistry radioUnitRegistry;
+    private static volatile Mediator UNIQUE_INSTANCE;
+    private final PropertyChangeSupport support;
+    private final CarrierManagementSystemDirector carrierManagement;
+    private final AbstractManagedRadioUnitRegistry radioUnitRegistry;
 
-	/**
-	 * Constructor for the Mediator class.
-	 * Required to be private to ensure the Singleton Pattern is followed.
-	 */
-	private Mediator() {
-		support = new PropertyChangeSupport(this);
-		carrierManagement = CarrierManagementSystemDirector.getInstance();
-		radioUnitRegistry = ManagedRadioUnitRegistry.getInstance();
-	}
+    /**
+     * Constructor for the Mediator class.
+     * Required to be private to ensure the Singleton Pattern is followed.
+     */
+    private Mediator() {
+        support = new PropertyChangeSupport(this);
+        carrierManagement = CarrierManagementSystemDirector.getInstance();
+        radioUnitRegistry = ManagedRadioUnitRegistry.getInstance();
+    }
 
-	/**
-	 * Get the unique Mediator instance.
-	 *
-	 * @return The Singleton instance of the Mediator class.
-	 */
-	public static Mediator getInstance() {
-		if (UNIQUE_INSTANCE == null) {
-			synchronized (Mediator.class) {
-				if (UNIQUE_INSTANCE == null) {
-					UNIQUE_INSTANCE = new Mediator();
-				}
-			}
-		}
-		return UNIQUE_INSTANCE;
-	}
+    /**
+     * Get the unique Mediator instance.
+     *
+     * @return The Singleton instance of the Mediator class.
+     */
+    public static Mediator getInstance() {
+        if (UNIQUE_INSTANCE == null) {
+            synchronized (Mediator.class) {
+                if (UNIQUE_INSTANCE == null) {
+                    UNIQUE_INSTANCE = new Mediator();
+                }
+            }
+        }
+        return UNIQUE_INSTANCE;
+    }
 
-	/**
-	 * Prints a formatted list of RUs currently registered with the mediator.
-	 */
-	private void printRegisteredRadioUnits() {
-		List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getAllRadios();
-		radioUnits.forEach(System.out::println);
-		if (radioUnits.size() == 0) {
-			System.out.println("[ERROR] No RUs have been registered with the system.");
-		} else {
-			radioUnits.forEach(System.out::println);
-		}
-	}
+    /**
+     * Prints a formatted list of RUs currently registered with the mediator.
+     */
+    private void printRegisteredRadioUnits() {
+        List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getAllRadios();
+        if (radioUnits.size() == 0) {
+            System.out.println("No RUs have been registered with the system.");
+        } else {
+            radioUnits.forEach(ru -> System.out.println(ru + "\n"));
+        }
+    }
 
-	/**
-	 * Create a radio unit that will be used in the system. This radio
-	 * unit will be stored and managed by the RadioUnitRegistry class.
-	 *
-	 * @param name    The name of the RU.
-	 * @param vendor  The vendor for the RU.
-	 * @param ratType The RAT type for the RU.
-	 */
-	private synchronized void createRu(String ip, String name, Vendor vendor, RatType ratType) {
-		radioUnitRegistry.addRadioUnit(ip, name, vendor, ratType);
-	}
+    /**
+     * Create a radio unit that will be used in the system. This radio
+     * unit will be stored and managed by the RadioUnitRegistry class.
+     *
+     * @param name    The name of the RU.
+     * @param vendor  The vendor for the RU.
+     * @param ratType The RAT type for the RU.
+     */
+    private synchronized void createRu(String ip, String name, Vendor vendor, RatType ratType) {
+        radioUnitRegistry.addRadioUnit(ip, name, vendor, ratType);
+    }
 
-	/**
-	 * Attempt to remove an radio unit from the radio unit registry.
-	 *
-	 * @param ip The IP associated with the radio unit that will be removed.
-	 */
-	private void removeRu(String ip) {
-		radioUnitRegistry.removeRadioUnit(ip);
-	}
+    /**
+     * Attempt to remove a radio unit from the radio unit registry.
+     *
+     * @param ip The IP associated with the radio unit that will be removed.
+     */
+    private void removeRu(String ip) {
+        radioUnitRegistry.removeRadioUnit(ip);
+    }
 
-	/**
-	 * Create a Carrier and add it to an existing RU.
-	 *
-	 * @param ip                 The IP address of the RU this carrier will be added to.
-	 * @param rfPorts            The RF Ports that will be used with this carrier.
-	 * @param carrierFrequencies The frequencies that will be used with this carrier.
-	 * @param transmittingPower  The transmitting power of the carrier.
-	 */
-	private synchronized void createCarrierOnRu(String ip, List<RfPort> rfPorts, FrequencyBand carrierFrequencies,
-			Double transmittingPower) {
-		ManagedRadioUnit ru = getRadioUnit(ip);
-		if (ru == null)
-		{
-			System.out.println("Unable to create carrier on Radio Unit: Radio Unit not found!");
-			return;
-		}
-		ru.setupCarrier(createCarrier(rfPorts, carrierFrequencies, transmittingPower, ru.getRatType()));
-	}
+    /**
+     * Create a Carrier and add it to an existing RU.
+     *
+     * @param ip                 The IP address of the RU this carrier will be added to.
+     * @param rfPorts            The RF Ports that will be used with this carrier.
+     * @param carrierFrequencies The frequencies that will be used with this carrier.
+     * @param transmittingPower  The transmitting power of the carrier.
+     */
+    private synchronized void createCarrierOnRu(String ip, List<RfPort> rfPorts, FrequencyBand carrierFrequencies,
+                                                Double transmittingPower) {
+        ManagedRadioUnit ru = getRadioUnit(ip);
+        if (ru == null) {
+            System.out.println("Unable to create carrier on Radio Unit: Radio Unit not found!");
+            return;
+        }
+        ru.setupCarrier(createCarrier(rfPorts, carrierFrequencies, transmittingPower, ru.getRatType()));
+    }
 
-	/**
-	 * Return a radio unit specified by a given IP address.
-	 *
-	 * @param ip The IP of the RU, as a String.
-	 * @return The radio unit associated with that specific ip.
-	 */
-	private ManagedRadioUnit getRadioUnit(String ip) {
-		return radioUnitRegistry.getByIpAddress(ip);
-	}
+    /**
+     * Return a radio unit specified by a given IP address.
+     *
+     * @param ip The IP of the RU, as a String.
+     * @return The radio unit associated with that specific ip.
+     */
+    private ManagedRadioUnit getRadioUnit(String ip) {
+        return radioUnitRegistry.getByIpAddress(ip);
+    }
 
-	/**
-	 * Create a carrier that will then be registered with the system. The carrier will have its type
-	 * determined based on the RAT type of the radio unit the carrier is being added to.
-	 *
-	 * @param rfPorts            A list of RF ports that will be used for this carrier.
-	 * @param carrierFrequencies The frequency band that will be used with this carrier.
-	 * @param transmittingPower  The transmitting power for this carrier.
-	 * @param ratType            The RAT type of the radio unit that this carrier will be associated with.
-	 * @return The created Carrier based on the RAT type of the radio unit it will be associated with.
-	 */
-	private synchronized Carrier createCarrier(List<RfPort> rfPorts, FrequencyBand carrierFrequencies, Double transmittingPower, RatType ratType) {
-		switch (ratType) {
-		case WCDMA:
-		{
-			try {
-				return carrierManagement.createWcdmaCarrier(rfPorts, carrierFrequencies, transmittingPower);
-			} catch (ArrayIndexOutOfBoundsException ex) {
-				return null;
-			}
-		}
-		case LTE:
-		{
-			try {
-				return carrierManagement.createLteCarrier(rfPorts, carrierFrequencies, transmittingPower);
-			} catch (ArrayIndexOutOfBoundsException ex) {
-				return null;
-			}
-		}
-		default:
-		{
-			System.out.print("[ERROR] Invalid RAT type detected, failed to create a carrier.");
-			return null;
-		}
-		}
-	}
+    /**
+     * Create a carrier that will then be registered with the system. The carrier will have its type
+     * determined based on the RAT type of the radio unit the carrier is being added to.
+     *
+     * @param rfPorts            A list of RF ports that will be used for this carrier.
+     * @param carrierFrequencies The frequency band that will be used with this carrier.
+     * @param transmittingPower  The transmitting power for this carrier.
+     * @param ratType            The RAT type of the radio unit that this carrier will be associated with.
+     * @return The created Carrier based on the RAT type of the radio unit it will be associated with.
+     */
+    private synchronized Carrier createCarrier(List<RfPort> rfPorts, FrequencyBand carrierFrequencies, Double transmittingPower, RatType ratType) {
+        switch (ratType) {
+            case WCDMA: {
+                try {
+                    return carrierManagement.createWcdmaCarrier(rfPorts, carrierFrequencies, transmittingPower);
+                } catch (ArrayIndexOutOfBoundsException ex) {
+                    return null;
+                }
+            }
+            case LTE: {
+                try {
+                    return carrierManagement.createLteCarrier(rfPorts, carrierFrequencies, transmittingPower);
+                } catch (ArrayIndexOutOfBoundsException ex) {
+                    return null;
+                }
+            }
+            default: {
+                System.out.print("[ERROR] Invalid RAT type detected, failed to create a carrier.");
+                return null;
+            }
+        }
+    }
 
-	/**
-	 * List any registered radio units that contain the parameter being passed.
-	 *
-	 * @param param The parameter that will be used to query for radio units. Examples
-	 *              include a RatType, a RadioUnitState, a FrequencyBand, or a String name.
-	 */
-	private void listRuByParam(Object param) {
-		if (param instanceof RatType) {
-			List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByRatType((RatType) param);
-			radioUnits.forEach(System.out::println);
-		} else if (param instanceof RadioUnitStateE) {
-			List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByState((RadioUnitStateE) param);
-			radioUnits.forEach(System.out::println);
-		} else if (param instanceof FrequencyBand) {
-			List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByBand((FrequencyBand) param);
-			radioUnits.forEach(System.out::println);
-		} else if (param instanceof String) {
-			List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByName((String) param);
-			radioUnits.forEach(System.out::println);
-		}
-	}
+    /**
+     * List any registered radio units that contain the parameter being passed.
+     *
+     * @param param The parameter that will be used to query for radio units. Examples
+     *              include a RatType, a RadioUnitState, a FrequencyBand, or a String name.
+     */
+    private void listRuByParam(Object param) {
+        if (param instanceof RatType) {
+            List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByRatType((RatType) param);
+            if (radioUnits.size() == 0) {
+                System.out.printf("No Radio Units with the RAT type \"%s\" exist in the system.\n", param);
+            } else {
+                radioUnits.forEach(ru -> System.out.println(ru + "\n"));
+            }
+        } else if (param instanceof RadioUnitStateE) {
+            List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByState((RadioUnitStateE) param);
+            if (radioUnits.size() == 0) {
+                System.out.printf("No Radio Units with the state \"%s\" exist in the system.\n", param);
+            } else {
+                radioUnits.forEach(ru -> System.out.println(ru + "\n"));
+            }
+        } else if (param instanceof FrequencyBand) {
+            List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByBand((FrequencyBand) param);
+            if (radioUnits.size() == 0) {
+                System.out.printf("No Radio Units with the state \"%s\" exist in the system.\n", param);
+            } else {
+                radioUnits.forEach(ru -> System.out.println(ru + "\n"));
+            }
+        } else if (param instanceof String) {
+            List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getByName((String) param);
+            if (radioUnits.size() == 0) {
+                System.out.printf("No Radio Units with the name \"%s\" exist in the system.\n", param);
+            } else {
+                radioUnits.forEach(ru -> System.out.println(ru + "\n"));
+            }
+        }
+    }
 
-	/**
-	 * Notify listeners of the RAT Type for a specific radio unit.
-	 *
-	 * @param evt The event that contains the necessary information to return alongside the RAT Type.
-	 */
-	@SuppressWarnings("unchecked")
-	private void messageRatType(PropertyChangeEvent evt) {
-		List<Object> params = ((ArrayList<Object>) evt.getNewValue());
-		ManagedRadioUnit radio = getRadioUnit((String) params.get(0));
-		if (radio == null)
-		{
-			System.out.println("Unable to message RAT type listeners: Radio Unit not found!");
-			return;
-		}
+    /**
+     * Notify listeners of the RAT Type for a specific radio unit.
+     *
+     * @param evt The event that contains the necessary information to return alongside the RAT Type.
+     */
+    @SuppressWarnings("unchecked")
+    private void messageRatType(PropertyChangeEvent evt) {
+        List<Object> params = ((ArrayList<Object>) evt.getNewValue());
+        ManagedRadioUnit radio = getRadioUnit((String) params.get(0));
+        if (radio == null) {
+            System.out.printf("No Radio Unit with the IP address \"%s\" was found in the system.\n", params.get(0));
+            return;
+        }
 
-		List<Object> newParams = new ArrayList<>(Arrays.asList(params.get(0), radio.getRatType()));
-		support.firePropertyChange(evt.getPropertyName(), params.get(1), newParams);
-	}
+        List<Object> newParams = new ArrayList<>(Arrays.asList(params.get(0), radio.getRatType()));
+        support.firePropertyChange(evt.getPropertyName(), params.get(1), newParams);
+    }
 
-	/**
-	 * Print all alarms currently raised in the network.
-	 */
+    /**
+     * This method gets called when a bound property is changed.
+     *
+     * @param evt A PropertyChangeEvent object describing the event source
+     *            and the property that has changed.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void propertyChange(PropertyChangeEvent evt) {
+        Procedure procedure = null;
+        for (Procedure currProcedure : Procedure.values()) {
+            if (currProcedure.getDesc().equals(evt.getPropertyName())) {
+                procedure = currProcedure;
+            }
+        }
 
-	/**
-	 * This method gets called when a bound property is changed.
-	 *
-	 * @param evt A PropertyChangeEvent object describing the event source
-	 *            and the property that has changed.
-	 */
-	@Override
-	@SuppressWarnings("unchecked")
-	public void propertyChange(PropertyChangeEvent evt) {
-		Procedure procedure = null;
-		for (Procedure currProcedure : Procedure.values()) {
-			if (currProcedure.getDesc().equals(evt.getPropertyName())) {
-				procedure = currProcedure;
-			}
-		}
+        ManagedRadioUnit radio;
+        List<Object> params;
 
-		ManagedRadioUnit radio;
-		List<Object> params;
+        switch (Objects.requireNonNull(procedure)) {
+            case COMMISSION:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case RAT_TYPE:
+                        messageRatType(evt);
+                        break;
+                    case SETUP:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to setup the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
+                        radio.setup();
+                        break;
+                    case ACTIVATE:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to activate the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
+                        radio.activate();
+                        break;
+                    case SCALING:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to perform signal scaling on the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
+                        radio.signalScaling();
+                        break;
+                    case POST:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to perform post activation on the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
+                        radio.postActivation();
+                        break;
+                    case DIAGNOSTIC:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to perform self diagnostics on the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
+                        radio.performSelfDiagnostics();
+                        break;
+                }
+                break;
+            case DECOMMISSION:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case RAT_TYPE:
+                        messageRatType(evt);
+                        break;
 
-		switch (Objects.requireNonNull(procedure)) {
-		case COMMISSION:
-			
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case RAT_TYPE:
-				messageRatType(evt);
-				break;
-			case SETUP:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Cannot process COMMISION event: Radio Unit not found!");
-					return;
-				}
-				radio.setup();
-				break;
-			case ACTIVATE:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Cannot process COMMISION event: Radio Unit not found!");
-					return;
-				}
-				radio.activate();
-				break;
-			case SCALING:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Cannot process COMMISION event: Radio Unit not found!");
-					return;
-				}
-				radio.signalScaling();
-				break;
-			case POST:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Cannot process COMMISION event: Radio Unit not found!");
-					return;
-				}
-				radio.postActivation();
-				break;
-			case DIAGNOSTIC:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Cannot process COMMISION event: Radio Unit not found!");
-					return;
-				}
-				radio.performSelfDiagnostics();
-				break;
-			}
-			break;
-		case DECOMMISSION:
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case RAT_TYPE:
-				messageRatType(evt);
-				break;
+                    case RELEASE:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to release the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
 
-			case RELEASE:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Unable to RELEASE Radio Unit: Radio Unit not found!");
-					return;
-				}
+                        radio.release();
+                        break;
 
-				radio.release();
-				break;
+                    case DEACTIVATE:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to deactivate the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
 
-			case DEACTIVATE:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Unbale to DEACTIVATE Radio Unit: Radio Unit not found!");
-					return;
-				}
+                        radio.deactivate();
+                        break;
 
-				radio.deactivate();
-				break;
+                    case CARRIER:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to remove all carriers from the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
 
-			case CARRIER:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Unable to remove all carriers from Radio Unit: Radio Unit not found!");
-					return;
-				}
+                        radio.removeAllCarriers();
+                        break;
+                }
+                break;
+            case CREATE:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case CARRIER:
+                        params = ((ArrayList<Object>) evt.getNewValue());
+                        createCarrierOnRu((String) params.get(0), (List<RfPort>) params.get(1), (FrequencyBand) params.get(2), (Double) params.get(3));
+                        break;
+                    case RU:
+                        params = ((ArrayList<Object>) evt.getNewValue());
+                        createRu((String) params.get(0), (String) params.get(1), (Vendor) params.get(2), (RatType) params.get(3));
+                        break;
+                    case ALARM:
+                        params = ((ArrayList<Object>) evt.getNewValue());
+                        radio = getRadioUnit((String) params.get(0));
+                        if (radio == null) {
+							System.out.printf("Unable to raise an alarm on the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", params.get(0));
+                            return;
+                        }
 
-				radio.removeAllCarriers();
-				break;
-			}
-			break;
-		case CREATE:
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case CARRIER:
-				params = ((ArrayList<Object>) evt.getNewValue());
-				createCarrierOnRu((String) params.get(0), (List<RfPort>) params.get(1), (FrequencyBand) params.get(2), (Double) params.get(3));
-				break;
-			case RU:
-				params = ((ArrayList<Object>) evt.getNewValue());
-				createRu((String) params.get(0), (String) params.get(1), (Vendor) params.get(2), (RatType) params.get(3));
-				break;
-			case ALARM:
-				params = ((ArrayList<Object>) evt.getNewValue());
-				radio = getRadioUnit((String) params.get(0));
-				if (radio == null)
-				{
-					System.out.println("Unable to raise alarm on radio: Radio Unit not found!");
-					return;
-				}
+                        radio.raiseAlarm((AlarmStatusLevel) params.get(1));
+                        break;
+                }
+                break;
+            case DELETE:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case CARRIER:
+                        params = ((ArrayList<Object>) evt.getNewValue());
+                        radio = getRadioUnit((String) params.get(0));
+                        if (radio == null) {
+							System.out.printf("Unable to remove the carrier from the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", params.get(0));
+                            return;
+                        }
 
-				radio.raiseAlarm((AlarmStatusLevel) params.get(1));
-				break;
-			}
-			break;
-		case DELETE:
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case CARRIER:
-				params = ((ArrayList<Object>) evt.getNewValue());
-				radio = getRadioUnit((String) params.get(0));
-				if (radio == null)
-				{
-					System.out.println("Unable to remove carrier from Radio Unit: Radio Unit not found!");
-					return;
-				}
+                        radio.removeCarrier((int) params.get(1));
+                        break;
+                    case RU:
+                        removeRu((String) evt.getNewValue());
+                        break;
+                }
+                break;
+            case LIST:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case FULL:
+                        printRegisteredRadioUnits();
+                        break;
+                    case PARAM:
+                        listRuByParam(evt.getNewValue());
+                        break;
+                    case RU:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+                            System.out.printf("Unable to list the Radio Unit details." +
+                                    "\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
+                        System.out.println(radio);
+                        break;
+                }
+                break;
+            case MODIFY:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case CARRIER:
+                        params = ((ArrayList<Object>) evt.getNewValue());
 
-				radio.removeCarrier((int) params.get(1));
-				break;
-			case RU:
-				removeRu((String) evt.getNewValue());
-				break;
-			}
-			break;
-		case LIST:
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case FULL:
-				printRegisteredRadioUnits();
-				break;
-			case PARAM:
-				listRuByParam(evt.getNewValue());
-				break;
-			case RU:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Unable to list Radio Unit details: Radio Unit not found!");
-					return;
-				}
+                        radio = getRadioUnit((String) params.get(0));
+                        if (radio == null) {
+                            System.out.printf("Unable to modify the carrier on the Radio Unit." +
+                                    "\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", params.get(0));
+                            return;
+                        }
 
-				System.out.println(radio);
-				break;
-			}
-			break;
-		case MODIFY:
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case CARRIER:
-				params = ((ArrayList<Object>) evt.getNewValue());
+                        radio.modifyCarrier((int) params.get(1), (FrequencyBand) params.get(2));
+                        break;
+                }
+                break;
+            case ACKNOWLEDGE:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case ALARM:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+                            System.out.printf("Unable to acknowledge an alarm on the Radio Unit." +
+                                    "\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
+                        radio.acknowledgeAlarm();
+                        break;
+                }
+                break;
+            case GET:
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case RAT_TYPE:
+                        radio = getRadioUnit((String) evt.getNewValue());
+                        if (radio == null) {
+							System.out.printf("Unable to get RAT type for the Radio Unit." +
+									"\nNo Radio Unit with the IP address \"%s\" was found in the system.\n", evt.getNewValue());
+                            return;
+                        }
 
-				radio = getRadioUnit((String) params.get(0));
-				if (radio == null)
-				{
-					System.out.println("Unable to modify carrier on Radio Unit: Radio Unit not found!");
-					return;
-				}
+                        support.firePropertyChange(Procedure.GET.getDesc(), ProcedureOptions.RAT_TYPE, radio.getRatType());
+                        break;
+                }
+                break;
+        }
+    }
 
-				radio.modifyCarrier((int) params.get(1), (FrequencyBand) params.get(2));
-				break;
-			}
-			break;
-		case ACKNOWLEDGE:
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case ALARM:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Unable to acknowledge alarm on Radio Unit: Radio Unit not found!");
-					return;
-				}
-
-				radio.acknowledgeAlarm();
-				break;
-			}
-			break;
-		case GET:
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case RAT_TYPE:
-				radio = getRadioUnit((String) evt.getNewValue());
-				if (radio == null)
-				{
-					System.out.println("Unable to get RAT type for Radio Unit: Radio Unit not found!");
-					return;
-				}
-
-				support.firePropertyChange(Procedure.GET.getDesc(), ProcedureOptions.RAT_TYPE, radio.getRatType());
-				break;
-			}
-			break;
-		}
-	}
-
-	/**
-	 * Add listeners to this class.
-	 *
-	 * @param pcl A property change listener.
-	 */
-	@Override
-	public void addPropertyChangeListener(PropertyChangeListener pcl) {
-		support.addPropertyChangeListener(pcl);
-	}
+    /**
+     * Add listeners to this class.
+     *
+     * @param pcl A property change listener.
+     */
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener pcl) {
+        support.addPropertyChangeListener(pcl);
+    }
 }

--- a/src/main/java/networkmanagementsystem/NetworkManagementClient.java
+++ b/src/main/java/networkmanagementsystem/NetworkManagementClient.java
@@ -5,670 +5,770 @@ import mediator.Mediator;
 import mediator.MediatorIf;
 
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Scanner;
-import java.util.regex.Pattern;
 import java.net.MalformedURLException;
-import java.rmi.RemoteException;
 import java.rmi.Naming;
+import java.rmi.RemoteException;
+import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * @author enuyhza
  */
 public class NetworkManagementClient {
-	public static final String NETWORK_MGMT_ID = "networkMgmtId";
+    public static final String NETWORK_MGMT_ID = "networkMgmtId";
 
-	private static NetworkManagementSystemIf networkManagementSys;
-	//define constants
-	static final int LTE_RF_PORTS_NUMBER = 4;
-	static final int WCDMA_RF_PORTS_NUMBER = 2;
+    private static NetworkManagementSystemIf networkManagementSys;
+    //define constants
+    private static final String INPUT_PROMPT = "> ";
+    private static final int LTE_RF_PORTS_NUMBER = 4;
+    private static final int WCDMA_RF_PORTS_NUMBER = 2;
+    private static final Pattern IP_PATTERN = Pattern.compile("^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\." +
+            "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\." +
+            "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\." +
+            "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$");
 
-	static final Pattern IP_PATTERN = Pattern.compile("^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\."
-			+ "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\."
-			+ "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\."
-			+ "([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$");
+    /**
+     * Entry-point into the application.
+     *
+     * @param args The command-line arguments passed during initialization.
+     */
+    public static void main(String[] args) {
+        setupObserverRelations();
 
-	/**
-	 * Entry-point into the application.
-	 *
-	 * @param args The command-line arguments passed during initialization.
-	 */
-	public static void main(String[] args) {
-		setupObserverRelations();
+        String option;
+        String ruName;
+        String ip;
+        int carrierId;
 
-		String option;
-		String ruName;
-		String ip;
-		int carrierId;
+        System.out.println(
+                		"#############################################################\n" +
+                        "##               NETWORK MANAGEMENT CLIENT                 ##\n" +
+                        "##                        TEAM A.2                         ##\n" +
+                        "##               ERICSSON OOP: SUMMER 2021                 ##\n" +
+                        "#############################################################\n");
+        System.out.println("Welcome!");
+        Scanner input = new Scanner(System.in);
+        do {
+            option = "-1";
+            try {
+                String menu = "\nPlease enter the number corresponding to the option you would like to choose:\n"
+                        + "0.	Exit Program\n"
+                        + "1.	Commission Radio Unit\n"
+                        + "2.	Decommission Radio Unit\n"
+                        + "3.	Add Radio Unit\n"
+                        + "4.	Remove Radio Unit\n"
+                        + "5.	Setup Radio Unit\n"
+                        + "6.	Release Radio Unit\n"
+                        + "7.	Activate Radio Unit\n"
+                        + "8.	Deactivate Radio Unit\n"
+                        + "9.	Setup Carrier on Radio Unit\n"
+                        + "10.	Modify Carrier on Radio Unit\n"
+                        + "11.	Remove Carrier on Radio Unit\n"
+                        + "12.	Remove all Carriers on Radio Unit\n"
+                        + "13.	Signal scaling on Radio Unit\n"
+                        + "14.	Post activation\n"
+                        + "15.	Perform self diagnostics\n"
+                        + "16.	List network Inventory\n"
+                        + "17.	List RUs details by standard (RAT type)\n"
+                        + "18.	List RUs details by state\n"
+                        + "19.	List RUs details by band\n"
+                        + "20.	List Radio Unit by IP address\n"
+                        + "21.	Set Alarm on Radio Unit\n"
+                        + "22.	List all Network Alarms\n"
+                        + "23.	Acknowledge Alarm on Radio Unit\n";
 
-		System.out.println("Welcome!");
-		Scanner input = new Scanner(System.in);
-		do {
-			option = "-1";
-			try {
-				String menu = "\nPlease enter the number corresponding to the option you would like to choose:\n"
-						+ "0.	Exit Program\n"
-						+ "1.	Commission Radio Unit\n"
-						+ "2.	Decommission Radio Unit\n"
-						+ "3.	Add Radio Unit\n"
-						+ "4.	Remove Radio Unit\n"
-						+ "5.	Setup Radio Unit\n"
-						+ "6.	Release Radio Unit\n"
-						+ "7.	Activate Radio Unit\n"
-						+ "8.	Deactivate Radio Unit\n"
-						+ "9.	Setup Carrier on Radio Unit\n"
-						+ "10.	Modify Carrier on Radio Unit\n"
-						+ "11.	Remove Carrier on Radio Unit\n"
-						+ "12.	Remove all Carriers on Radio Unit\n"
-						+ "13.	Signal scaling on Radio Unit\n"
-						+ "14.	Post activation\n"
-						+ "15.	Perform self diagnostics\n"
-						+ "16.	List network Inventory\n"
-						+ "17.	List RUs by standard(RAT type)\n"
-						+ "18.	List RUs by state\n"
-						+ "19.	List RUs by Band\n"
-						+ "20.	List Radio Unit details\n"
-						+ "21.	Set Alarm on Radio Unit\n"
-						+ "22.	List all Network Alarms\n"
-						+ "23.	Acknowledge Alarm on Radio Unit";
+                System.out.print(menu);
+                System.out.print(INPUT_PROMPT);
+                option = input.next().trim();
 
-				System.out.println(menu);
-				option = input.next();
-				
-				FrequencyBand freqBand;
-				RatType ratType;
-				
-				switch (option) {
-				case "0":
-					System.out.println("Goodbye!\n");
-					option = "0";
-					break;
-				case "1":
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.commissionRu(ip);
-					break;
-				case "2":
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}					
-					networkManagementSys.decommissionRu(ip);
-					break;
-				case "3":
-					// 3.Add(create) Radio Unit
-					// get vendor
-					System.out.println("Please enter a name for the Radio Unit:\n"
-							+ "For example: LTE#1\n"
-							+ "Enter 'Back' to go back to the menu\n");
-					ruName = input.next();
-					if (ruName.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					Vendor vendor = chooseVendor(input);
-					if (vendor == null) {
-						break;
-					}
-					ratType = chooseRatType(input);
-					if (ratType == null) {
-						break;
-					}
-					Random r = new Random();
-					ip = r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256);
-					networkManagementSys.addRadioUnit(ip, ruName, vendor, ratType);
-					break;
-				case "4":
-					// 4.Remove(delete) Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}					
-					networkManagementSys.removeRadioUnit(ip);
-					break;
-				case "5":
-					//5.Setup Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.setupRu(ip);
-					break;
-				case "6":
-					//6.Release Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.releaseRu(ip);
-					break;
-				case "7":
-					//7.Activate Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.activateRu(ip);
-					break;
-				case "8":
-					//8.Deactivate Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.deactivateRu(ip);
-					break;
-				case "9":
-					// 9.Setup Carrier on Radio Unit
-					System.out.println("To setup a carrier on Radio Unit, you need to have a Radio Unit ready first");
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					createCarrierOnRu(ip, input);
-					break;
-				case "10":
-					// 10.Modify Carrier on Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					carrierId = getCarrierId(input);
-					freqBand = chooseFreqBand(networkManagementSys.getRuRatType(ip), input);
-					if (freqBand == null) {
-						break;
-					}
-					networkManagementSys.modifyCarrierOnRu(ip, carrierId, freqBand);
-					break;
-				case "11":
-					//11.Remove Carrier on Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					carrierId = getCarrierId(input);
-					networkManagementSys.removeCarrierOnRu(ip, carrierId);
-					break;
-				case "12":
-					//12.Remove all Carriers on Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.removeAllCarriersOnRu(ip);
-					break;
-				case "13":
-					//13.Signal scaling on Radio Unit
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.signalScalingOnRu(ip);
-					break;
-				case "14":
-					//14.Post activation
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.postActivation(ip);
-					break;
-				case "15":
-					//15.Perform self diagnostics
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.performSelfDiagnostics(ip);
-					break;
-				case "16":
-					//16.List network Inventory
-					networkManagementSys.listNetworkInventory();
-					break;
-				case "17":
-					//17.List RUs by standard
-					ratType = chooseRatType(input);
-					if (ratType == null) {
-						break;
-					}
-					networkManagementSys.listRuByParam(ratType);
-					break;
-				case "18":
-					//18.List RUs by state
-					RadioUnitStateE state = chooseRuState(input);
-					networkManagementSys.listRuByParam(state);
-					break;
-				case "19":
-					//19.List RUs by Band
-					ratType = chooseRatType(input);
-					if (ratType == null) {
-						break;
-					}
-					freqBand = chooseFreqBand(ratType, input);
-					if (freqBand == null) {
-						break;
-					}
-					networkManagementSys.listRuByParam(freqBand);
-					break;
-				case "20":
-					//20.List Radio Unit details
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					networkManagementSys.listRadioUnitDetails(ip);
-					break;
-				case "21":
-					//21.Set Alarm on RU
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					AlarmStatusLevel alarm = chooseAlarmStatusLevel(input);
-					networkManagementSys.setAlarmOnRu(ip, alarm);
-					break;
-				case "22": //22.List all Network Alarms
-					String result = networkManagementSys.getNetworkAlarms();
-					System.out.println(result);
-					break;
-				case "23": 
-					//23.Acknowledge alarm on RU
-					ip = getIpAddress(input);
-					if (ip.equalsIgnoreCase("BACK")) {
-						break;
-					}
-					boolean success = networkManagementSys.acknowledgeAlarm(ip);
-					if (success)
-					{
-						System.out.println("Successfully acknowledged alarm");
-					}
-					else
-					{
-						System.out.println("Failed to acknowledge alarm");
-					}
+                FrequencyBand freqBand;
+                RatType ratType;
 
-					networkManagementSys.acknowledgeAlarm(ip);
+                switch (option) {
+                    case "0":
+                        System.out.println("\nGoodbye!");
+                        input.close();
+                        option = "0";
+                        break;
+                    case "1":
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        networkManagementSys.commissionRu(ip);
+						returnToMenu();
+                        break;
+                    case "2":
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        networkManagementSys.decommissionRu(ip);
+						returnToMenu();
+                        break;
+                    case "3":
+                        // 3.Add(create) Radio Unit
+                        // get vendor
+                        System.out.println("\nPlease enter a name for the Radio Unit.\n"
+                                + "For example: LTE#1\n"
+                                + "Enter 'Back' to go back to the menu");
+                        System.out.print(INPUT_PROMPT);
+                        input.nextLine();
+                        ruName = input.nextLine().trim();
+                        if (ruName.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        Vendor vendor = chooseVendor(input);
+                        if (vendor == null) {
+                            break;
+                        }
+                        ratType = chooseRatType(input);
+                        if (ratType == null) {
+                            break;
+                        }
+                        Random r = new Random();
+                        ip = r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256) + "." + r.nextInt(256);
+                        networkManagementSys.addRadioUnit(ip, ruName, vendor, ratType);
+                        returnToMenu();
+                        break;
+                    case "4":
+                        // 4.Remove(delete) Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        networkManagementSys.removeRadioUnit(ip);
+                        returnToMenu();
+                        break;
+                    case "5":
+                        //5.Setup Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        networkManagementSys.setupRu(ip);
+						returnToMenu();
+                        break;
+                    case "6":
+                        //6.Release Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        networkManagementSys.releaseRu(ip);
+						returnToMenu();
+                        break;
+                    case "7":
+                        //7.Activate Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        networkManagementSys.activateRu(ip);
+						returnToMenu();
+                        break;
+                    case "8":
+                        //8.Deactivate Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        networkManagementSys.deactivateRu(ip);
+						returnToMenu();
+                        break;
+                    case "9":
+                        // 9.Setup Carrier on Radio Unit
+                        System.out.println("To setup a carrier on Radio Unit, you need to have a Radio Unit ready first");
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        if (createCarrierOnRu(ip, input)) {
+                            returnToMenu();
+                        }
+                        break;
+                    case "10":
+                        // 10.Modify Carrier on Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        carrierId = getCarrierId(input);
+                        if (carrierId == -1) {
+                            break;
+                        }
+                        freqBand = chooseFreqBand(networkManagementSys.getRuRatType(ip), input);
+                        if (freqBand == null) {
+                            break;
+                        }
+                        networkManagementSys.modifyCarrierOnRu(ip, carrierId, freqBand);
+						returnToMenu();
+                        break;
+                    case "11":
+                        //11.Remove Carrier on Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        carrierId = getCarrierId(input);
+                        if (carrierId == -1) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.removeCarrierOnRu(ip, carrierId);
+						returnToMenu();
+                        break;
+                    case "12":
+                        //12.Remove all Carriers on Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.removeAllCarriersOnRu(ip);
+						returnToMenu();
+                        break;
+                    case "13":
+                        //13.Signal scaling on Radio Unit
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.signalScalingOnRu(ip);
+						returnToMenu();
+                        break;
+                    case "14":
+                        //14.Post activation
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.postActivation(ip);
+						returnToMenu();
+                        break;
+                    case "15":
+                        //15.Perform self diagnostics
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.performSelfDiagnostics(ip);
+						returnToMenu();
+                        break;
+                    case "16":
+                        //16.List network Inventory
+                        System.out.println();
+                        networkManagementSys.listNetworkInventory();
+                        returnToMenu();
+                        break;
+                    case "17":
+                        //17.List RUs by standard
+                        input.nextLine();
+                        ratType = chooseRatType(input);
+                        if (ratType == null) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.listRuByParam(ratType);
+                        returnToMenu();
+                        break;
+                    case "18":
+                        //18.List RUs by state
+                        RadioUnitStateE state = chooseRuState(input);
+                        if (state == null) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.listRuByParam(state);
+                        returnToMenu();
+                        break;
+                    case "19":
+                        //19.List RUs by Band
+                        ratType = chooseRatType(input);
+                        if (ratType == null) {
+                            break;
+                        }
+                        freqBand = chooseFreqBand(ratType, input);
+                        if (freqBand == null) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.listRuByParam(freqBand);
+                        returnToMenu();
+                        break;
+                    case "20":
+                        //20.List Radio Unit details
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        System.out.println();
+                        networkManagementSys.listRadioUnitDetails(ip);
+                        returnToMenu();
+                        break;
+                    case "21":
+                        //21.Set Alarm on RU
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        AlarmStatusLevel alarm = chooseAlarmStatusLevel(input);
+                        if (alarm == null) {
+                        	break;
+						}
+                        System.out.println();
+                        networkManagementSys.setAlarmOnRu(ip, alarm);
+                        returnToMenu();
+                        break;
+                    case "22":
+                        //22.List all Network Alarms
+                        networkManagementSys.getNetworkAlarms();
+                        returnToMenu();
+                        break;
+                    case "23":
+                        //23.Acknowledge alarm on RU
+                        ip = getIpAddress(input);
+                        if (ip.equalsIgnoreCase("BACK")) {
+                            break;
+                        }
+                        System.out.println();
+                        if (networkManagementSys.acknowledgeAlarm(ip)) {
+                            System.out.printf("Successfully acknowledged alarm on the Radio Unit with the IP address \"%s\"", ip);
+                        } else {
+                            System.out.printf("Failed to acknowledge alarm on the Radio Unit with the IP address \"%s\"", ip);
+                        }
+                        returnToMenu();
+                        break;
+                    default:
+                        System.out.println("Unsupported option, please try again!");
+                        break;
+                }
 
-					break;
-				default:
-					System.out.println("Unsupported option, please try again!");
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.out.println("Invalid input, please try again!");
+            }
+
+        } while (!option.equals("0"));
+        System.exit(0);
+    } // main
+
+    private static void returnToMenu() {
+        System.out.print("\nPlease press the Enter key to return to the main menu.");
+        try {
+            System.in.read();
+        } catch (Exception e) {
+        }
+    }
+
+    /**
+     * Helper method that get the alarm from user.
+     * Returns the alarm user selected.
+     *
+     * @param input Scanner instance to get user input.
+     * @return An alarm from the AlarmStatusLevel enum.
+     */
+    private static AlarmStatusLevel chooseAlarmStatusLevel(Scanner input) {
+        AlarmStatusLevel alarm = null;
+        int i;
+
+        do {
+        	i = 0;
+			System.out.println("Please choose an Alarm for the Radio Unit.");
+			for (AlarmStatusLevel currAlarm : AlarmStatusLevel.values()) {
+				System.out.println("	" + ++i + ".	" + currAlarm.toString());
+				if (i == 3) {
 					break;
 				}
-
-			} catch (Exception e) {
-				e.printStackTrace();
-				System.out.println("Invalid input, please try again!");
 			}
-
-		} while (!option.equals("0"));
-	} // main
-
-	/**
-	 * Helper method that get the alarm from user.
-	 * Returns the alarm user selected.
-	 *
-	 * @param input Scanner instance to get user input.
-	 * @return A alarm from the AlarmStatusLevel enum.
-	 */
-	private static AlarmStatusLevel chooseAlarmStatusLevel(Scanner input) {
-		AlarmStatusLevel alarm = null;
-		int i = 0;
-		System.out.println("Please choose an Alarm for Radio Unit:");
-		for (AlarmStatusLevel currAlarm : AlarmStatusLevel.values()) {
-			System.out.println("	" + ++i + ".	" + currAlarm.toString());
-			if (i == 3) {
-				break;
-			}
-		}
-
-		do {
-			String subOption = input.next();
-			try {
-				if (i < 4) {
-					alarm = AlarmStatusLevel.values()[Integer.parseInt(subOption) - 1];
-				} else {
-					throw new NumberFormatException();
-				}
-			} catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
-				System.out.println("Invalid input, please try again.");
-			}
-		} while (alarm == null);
-
-		return alarm;
-	}
-
-	/**
-	 * Prepare Observer relations between classes.
-	 * Currently these includes the Commission/Decommission classes, the
-	 * NetworkManagementSystem, the Mediator, and the NetworkManagementClient.
-	 */
-	private static void setupObserverRelations() {
-		// Setup Observer relations
-		MediatorIf mediator = Mediator.getInstance();
-		networkManagementSys = NetworkManagementSystem.getInstance();
-
-		try {
-			Naming.rebind(NETWORK_MGMT_ID, networkManagementSys);
-
-			networkManagementSys.addPropertyChangeListener((PropertyChangeListener) mediator);
-			mediator.addPropertyChangeListener((PropertyChangeListener) networkManagementSys);
-
-			for (Map.Entry<RatType, CommissionRadioUnit> entry : networkManagementSys.getCommissioners().entrySet()) {
-				entry.getValue().addPropertyChangeListener((PropertyChangeListener) mediator);
-			}
-
-			for (Map.Entry<RatType, DecommissionRadioUnit> entry : networkManagementSys.getDecommissioners().entrySet()) {
-				entry.getValue().addPropertyChangeListener((PropertyChangeListener) mediator);
-			}
-		} catch (RemoteException | MalformedURLException ex)
-		{
-			System.out.println("Failed to connect to remote server");
-			ex.printStackTrace();
-			System.exit(0);
-		}
-	}
-
-
-	/**
-	 * Helper method that create a carrier on existing RU based on user-choose
-	 * RAT type, RF Ports, Frequency band and transmitting power.
-	 * The option also exists to create a stand-alone carrier that will
-	 * not be added to an RU on creation.
-	 *
-	 * @param ip    The name of the radio unit to create carrier on.
-	 *              Pass as null to create carrier that isn't associated
-	 *              with an RU.
-	 * @param input Scanner instance to get user input.
-	 */
-
-	private static void createCarrierOnRu(String ip, Scanner input) {
-		List<RfPort> rfPorts;
-		FrequencyBand freqBand;
-		double transPower;
-
-		try {
-			// Get the RatType of the RU we are currently looking at.
-			RatType currRatType = networkManagementSys.getRuRatType(ip);
-
-			//get RF Ports
-			int noOfRfPorts;
-			if (currRatType.equals(RatType.LTE)) {
-				noOfRfPorts = LTE_RF_PORTS_NUMBER;
-			} else {
-				noOfRfPorts = WCDMA_RF_PORTS_NUMBER;
-			}
-			rfPorts = chooseRfPorts(currRatType, noOfRfPorts, input);
-			if (rfPorts.size() < noOfRfPorts) {
-				return;
-			}
-
-			//get Frequency band
-			freqBand = chooseFreqBand(currRatType, input);
-			if (freqBand == null) {
-				return;
-			}
-
-			//get transmitting power
-			transPower = getTransPower(input);
-			if (transPower == -99999) {
-				return;
-			}
-
-			networkManagementSys.setupCarrierOnRu(ip, rfPorts, freqBand, transPower);
-		} catch (RemoteException ex)
-		{
-			System.out.println("Failed to connect to remote server");
-			ex.printStackTrace();
-			System.exit(0);
-		}
-
-	}
-
-	/**
-	 * Helper method to get the Carrier ID from user
-	 * Returns the Carrier ID user entered
-	 *
-	 * @param input Scanner instance to get user input.
-	 * @return Radio Unit State Enum.
-	 */
-	private static RadioUnitStateE chooseRuState(Scanner input) {
-		RadioUnitStateE state = null;
-		int i = 0;
-		System.out.println("Please choose Radio Unit State:");
-		for (RadioUnitStateE ruState : RadioUnitStateE.values()) {
-			System.out.println("	" + ++i + ".	" + ruState.getRuState());
-		}
-
-		do {
-			String subOption = input.next();
-			try {
-				state = RadioUnitStateE.values()[Integer.parseInt(subOption) - 1];
-			} catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
-				System.out.println("Invalid input, please try again.");
-			}
-		} while (state == null);
-
-		return state;
-	}
-
-	/**
-	 * Helper method to get the Carrier ID from user
-	 * Returns the Carrier ID user entered
-	 *
-	 * @param input Scanner instance to get user input.
-	 * @return Carrier ID, as an int.
-	 */
-	private static int getCarrierId(Scanner input) {
-		int carrierId;
-		do {
-			System.out.println("Please enter the Carrier ID:");
-			String id = input.next();
-			try {
-				carrierId = Integer.parseInt(id);
-				break;
-			} catch (NumberFormatException e) {
-				System.out.println("'" + id + "'" + " is not a valid number, Try again!");
-			}
-		} while (true);
-
-		return carrierId;
-	}
-
-
-	/**
-	 * Helper method to get the IP address of the radio unit from user
-	 * Returns the IP address user entered
-	 *
-	 * @param input Scanner instance to get user input.
-	 * @return IP address, as a String.
-	 */
-	private static String getIpAddress(Scanner input) {
-		String ip;
-		do {
-			System.out.println("Please enter the IP address of the Radio Unit you want to operate on:\n"
-					         + "Enter 'Back' to go back to the menu\n");
-			ip = input.next();
-			if (ip.equalsIgnoreCase("BACK")) {
-				break;
-			}
-			if (IP_PATTERN.matcher(ip).matches()) {
-				System.out.println("IP address is fine.");
-				break;
-			}
-			System.out.println("Invalid IP address format, please try again: " + ip);
-		} while (true);
-
-		return ip;
-	}
-
-	/**
-	 * Helper method that get the transmitting power for carrier from user
-	 * Returns the transmitting power user entered
-	 *
-	 * @param input Scanner instance to get user input.
-	 * @return The transmitting power, as a double.
-	 */
-	private static double getTransPower(Scanner input) {
-		double transPower = -99999;
-		System.out.println("Please enter a number for transmitting Power:\n"
-				+ "Enter 'Back' to go back to the menu\n");
-		do {
-			String transPowerText = input.next();
-			if (transPowerText.equalsIgnoreCase("BACK")) {
-				break;
-			}
-			try {
-				transPower = Double.parseDouble(transPowerText);
-				break;
-			} catch (NumberFormatException e) {
-				System.out.println("'" + transPowerText + "'" + " is not a valid number, Try again!");
-			}
-		} while (true);
-		return transPower;
-	}
-
-
-	/**
-	 * Helper method that get the vendor from user.
-	 * Returns the vendor user selected.
-	 *
-	 * @param input Scanner instance to get user input.
-	 * @return A vendor from the Vendor enum.
-	 */
-	private static Vendor chooseVendor(Scanner input) {
-		Vendor vendor = null;
-		int i = 0;
-		System.out.println("Please choose a Vendor for Radio Unit:\n"
-						 + "Enter 'Back' to go back to the menu\n");
-		for (Vendor currVendor : Vendor.values()) {
-			System.out.println("	" + ++i + ".	" + currVendor.toString());
-		}
-
-		do {
-			String subOption = input.next();
+			System.out.println("Enter 'Back' to go back to the menu.\n");
+			System.out.print(INPUT_PROMPT);
+            String subOption = input.nextLine().trim();
 			if (subOption.equalsIgnoreCase("BACK")) {
 				break;
 			}
-			try {
-				vendor = Vendor.values()[Integer.parseInt(subOption) - 1];
-			} catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
-				System.out.println("Invalid input, please try again.");
-			}
-		} while (vendor == null);
+            try {
+                if (i < 4) {
+                    alarm = AlarmStatusLevel.values()[Integer.parseInt(subOption) - 1];
+                } else {
+                    throw new NumberFormatException();
+                }
+            } catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
+                System.out.println("Invalid input, please try again.");
+            }
+        } while (alarm == null);
 
-		return vendor;
-	}
+        return alarm;
+    }
 
-	/**
-	 * Helper method that get the RAT type from user.
-	 * Returns the RAT type the user selected.
-	 *
-	 * @param input Scanner instance to get user input.
-	 * @return The RAT type selected by the user.
-	 */
-	private static RatType chooseRatType(Scanner input) {
-		RatType rat = null;
-		int i = 0;
-		System.out.println("\nPlease choose a RAT type:\n"
-						 + "Enter 'Back' to go back to the menu\n");
-		for (RatType currRatType : RatType.values()) {
-			System.out.println("	" + ++i + ".	" + currRatType.toString());
-		}
-		do {
-			String subOption = input.next();
-			if (subOption.equalsIgnoreCase("BACK")) {
-				break;
-			}
-			try {
-				rat = RatType.values()[Integer.parseInt(subOption) - 1];
-			} catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
-				System.out.println("Invalid input, please try again.");
-			}
-		} while (rat == null);
+    /**
+     * Prepare Observer relations between classes.
+     * Currently, these include the Commission/Decommission classes, the
+     * NetworkManagementSystem, the Mediator, and the NetworkManagementClient.
+     */
+    private static void setupObserverRelations() {
+        // Setup Observer relations
+        MediatorIf mediator = Mediator.getInstance();
+        networkManagementSys = NetworkManagementSystem.getInstance();
 
-		return rat;
-	}
+        try {
+            Naming.rebind(NETWORK_MGMT_ID, networkManagementSys);
+
+            networkManagementSys.addPropertyChangeListener((PropertyChangeListener) mediator);
+            mediator.addPropertyChangeListener((PropertyChangeListener) networkManagementSys);
+
+            for (Map.Entry<RatType, CommissionRadioUnit> entry : networkManagementSys.getCommissioners().entrySet()) {
+                entry.getValue().addPropertyChangeListener((PropertyChangeListener) mediator);
+            }
+
+            for (Map.Entry<RatType, DecommissionRadioUnit> entry : networkManagementSys.getDecommissioners().entrySet()) {
+                entry.getValue().addPropertyChangeListener((PropertyChangeListener) mediator);
+            }
+        } catch (RemoteException | MalformedURLException ex) {
+            System.out.println("Failed to connect to remote server");
+            ex.printStackTrace();
+            System.exit(0);
+        }
+    }
 
 
-	/**
-	 * Helper method that get the RF Ports from user.
-	 * Returns a list of RF Ports.
-	 *
-	 * @param ratType The RAT type of the RF ports being requested.
-	 * @param input   Scanner instance to get user input.
-	 * @return The RfPorts that were selected by the user, as a List.
-	 */
-	private static List<RfPort> chooseRfPorts(RatType ratType, int noOfRfPorts, Scanner input) {
-		List<RfPort> ports = new ArrayList<>();
-		int count = 0;
+    /**
+     * Helper method that create a carrier on existing RU based on user-choose
+     * RAT type, RF Ports, Frequency band and transmitting power.
+     * The option also exists to create a stand-alone carrier that will
+     * not be added to an RU on creation.
+     *
+     * @param ip    The name of the radio unit to create carrier on.
+     *              Pass as null to create carrier that isn't associated
+     *              with an RU.
+     * @param input Scanner instance to get user input.
+     * @return True if a Carrier was created, false otherwise.
+     */
 
-		int i = 0;
-		System.out.printf("Please choose %d RF ports\n"
-						+ "Enter 'Back' to go back to the menu\n", noOfRfPorts);
-		for (RfPort currRfPort : RfPort.values()) {
-			System.out.println("	" + ++i + ".	" + currRfPort.toString());
-		}
-		do {
-			String subOption = input.next();
-			if (subOption.equalsIgnoreCase("BACK")) {
-				break;
-			}
-			try {
-				ports.add(RfPort.values()[Integer.parseInt(subOption) - 1]);
-				count++;
-			} catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
-				System.out.println("Invalid input, please try again.");
-				continue;
-			}
-			if (count != noOfRfPorts) {
-				System.out.println("Enter next number:");
-			}
-		} while (count < noOfRfPorts);
-		return ports;
-	}
+    private static boolean createCarrierOnRu(String ip, Scanner input) {
+        List<RfPort> rfPorts;
+        FrequencyBand freqBand;
+        double transPower;
 
-	/**
-	 * Helper method that get the frequency band from user.
-	 * Returns the frequency band user choose.
-	 *
-	 * @param ratType The RAT type of the frequency bands being requested.
-	 * @param input   Scanner instance to get user input.
-	 * @return The frequency band the user selected, as a FrequencyBand enum entry.
-	 */
-	private static FrequencyBand chooseFreqBand(RatType ratType, Scanner input) {
-		FrequencyBand freqBand = null;
-		int i = 0;
-		System.out.println("Please choose Carrier Frequency Band:\n"
-				         + "Enter 'Back' to go back to the menu\n");
-		if (!ratType.equals(RatType.LTE)) {
-			for (WcdmaFrequencyBand currWcdmaFreq : WcdmaFrequencyBand.values()) {
-				System.out.println("	" + ++i + ".	" + currWcdmaFreq.toString());
-			}
-		} else {
-			for (LteFrequencyBand currLteFreq : LteFrequencyBand.values()) {
-				System.out.println("	" + ++i + ".	" + currLteFreq.toString());
-			}
-		}
-		do {
-			String subOption = input.next();
-			if (subOption.equalsIgnoreCase("BACK")) {
-				break;
-			}
-			try {
-				if (ratType.equals(RatType.LTE)) {
-					freqBand = LteFrequencyBand.values()[Integer.parseInt(subOption) - 1];
-				} else {
-					freqBand = WcdmaFrequencyBand.values()[Integer.parseInt(subOption) - 1];
-				}
-			} catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
-				System.out.println("Invalid input, please try again.");
-			}
-		} while (freqBand == null);
+        try {
+            // Get the RatType of the RU we are currently looking at.
+            RatType currRatType = networkManagementSys.getRuRatType(ip);
 
-		return freqBand;
-	}
+            if (currRatType == null) {
+                return false;
+            }
+
+            System.out.println();
+
+            //get RF Ports
+            int noOfRfPorts;
+            if (currRatType.equals(RatType.LTE)) {
+                noOfRfPorts = LTE_RF_PORTS_NUMBER;
+            } else {
+                noOfRfPorts = WCDMA_RF_PORTS_NUMBER;
+            }
+            rfPorts = chooseRfPorts(noOfRfPorts, input);
+            if (rfPorts.size() < noOfRfPorts) {
+                return false;
+            }
+
+            System.out.println();
+
+            //get Frequency band
+            freqBand = chooseFreqBand(currRatType, input);
+            if (freqBand == null) {
+                return false;
+            }
+
+            System.out.println();
+
+            //get transmitting power
+            transPower = getTransPower(input);
+            if (transPower == -99999) {
+                return false;
+            }
+
+            System.out.println();
+            networkManagementSys.setupCarrierOnRu(ip, rfPorts, freqBand, transPower);
+        } catch (RemoteException ex) {
+            System.out.println("Failed to connect to remote server");
+            ex.printStackTrace();
+            System.exit(0);
+        }
+        return true;
+    }
+
+    /**
+     * Helper method to get the Carrier ID from user
+     * Returns the Carrier ID user entered
+     *
+     * @param input Scanner instance to get user input.
+     * @return Radio Unit State Enum.
+     */
+    private static RadioUnitStateE chooseRuState(Scanner input) {
+        RadioUnitStateE state = null;
+        int i;
+
+        do {
+            i = 0;
+            System.out.println("Please choose the Radio Unit State.");
+            for (RadioUnitStateE ruState : RadioUnitStateE.values()) {
+                System.out.println("	" + ++i + ".	" + ruState.getRuState());
+            }
+            System.out.println("Enter 'Back' to go back to the menu.");
+            System.out.print(INPUT_PROMPT);
+            String subOption = input.nextLine().trim();
+            if (subOption.equalsIgnoreCase("BACK")) {
+                break;
+            }
+            try {
+                state = RadioUnitStateE.values()[Integer.parseInt(subOption) - 1];
+            } catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
+                System.out.println("Invalid input, please try again.");
+            }
+        } while (state == null);
+
+        return state;
+    }
+
+    /**
+     * Helper method to get the Carrier ID from user
+     * Returns the Carrier ID user entered
+     *
+     * @param input Scanner instance to get user input.
+     * @return Carrier ID, as an int.
+     */
+    private static int getCarrierId(Scanner input) {
+        int carrierId;
+        do {
+            System.out.print("Please enter the Carrier ID.\n"
+                    + "Enter 'Back' to go back to the menu\n");
+			System.out.print(INPUT_PROMPT);
+            String id = input.nextLine().trim();
+            if (id.equalsIgnoreCase("BACK")) {
+                return -1;
+            }
+            try {
+                carrierId = Integer.parseInt(id);
+                break;
+            } catch (NumberFormatException e) {
+                System.out.println("'" + id + "'" + " is not a valid number, Try again!");
+            }
+        } while (true);
+
+        return carrierId;
+    }
+
+
+    /**
+     * Helper method to get the IP address of the radio unit from user
+     * Returns the IP address user entered
+     *
+     * @param input Scanner instance to get user input.
+     * @return IP address, as a String.
+     */
+    private static String getIpAddress(Scanner input) {
+        String ip;
+        input.nextLine();
+        do {
+            System.out.print("\nPlease enter the IP address of the Radio Unit you want to operate on.\n"
+                    + "Enter 'Back' to go back to the menu\n");
+            System.out.print(INPUT_PROMPT);
+            ip = input.nextLine().trim();
+            if (ip.equalsIgnoreCase("BACK")) {
+                break;
+            }
+            if (IP_PATTERN.matcher(ip).matches()) {
+                break;
+            }
+            System.out.println("Input is not a valid IP address: " + ip + "\nPlease try again.");
+        } while (true);
+
+        return ip;
+    }
+
+    /**
+     * Helper method that get the transmitting power for carrier from user
+     * Returns the transmitting power user entered
+     *
+     * @param input Scanner instance to get user input.
+     * @return The transmitting power, as a double.
+     */
+    private static double getTransPower(Scanner input) {
+        double transPower = -99999;
+        do {
+            System.out.println("Please enter a number for the transmitting power.\n"
+                    + "Enter 'Back' to go back to the menu");
+            System.out.print(INPUT_PROMPT);
+            String transPowerText = input.next();
+            if (transPowerText.equalsIgnoreCase("BACK")) {
+                break;
+            }
+            try {
+                transPower = Double.parseDouble(transPowerText);
+                break;
+            } catch (NumberFormatException e) {
+                System.out.println("'" + transPowerText + "'" + " is not a valid number, Try again!");
+            }
+        } while (true);
+        return transPower;
+    }
+
+
+    /**
+     * Helper method that get the vendor from user.
+     * Returns the vendor user selected.
+     *
+     * @param input Scanner instance to get user input.
+     * @return A vendor from the Vendor enum.
+     */
+    private static Vendor chooseVendor(Scanner input) {
+        Vendor vendor = null;
+        int i;
+
+        do {
+            i = 0;
+            System.out.println("\nPlease choose a Vendor for the Radio Unit.");
+            for (Vendor currVendor : Vendor.values()) {
+                System.out.println("	" + ++i + ".	" + currVendor.getLabel());
+            }
+            System.out.println("Enter 'Back' to go back to the menu.");
+            System.out.print(INPUT_PROMPT);
+            String subOption = input.nextLine().trim();
+            if (subOption.equalsIgnoreCase("BACK")) {
+                break;
+            }
+            try {
+                vendor = Vendor.values()[Integer.parseInt(subOption) - 1];
+            } catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
+                System.out.println("Invalid input, please try again.");
+            }
+        } while (vendor == null);
+
+        return vendor;
+    }
+
+    /**
+     * Helper method that get the RAT type from user.
+     * Returns the RAT type the user selected.
+     *
+     * @param input Scanner instance to get user input.
+     * @return The RAT type selected by the user.
+     */
+    private static RatType chooseRatType(Scanner input) {
+        RatType rat = null;
+        int i;
+        do {
+            i = 0;
+            System.out.println("\nPlease choose a RAT type for the Radio Unit.");
+            for (RatType currRatType : RatType.values()) {
+                System.out.println("	" + ++i + ".	" + currRatType.getLabel());
+            }
+            System.out.println("Enter 'Back' to go back to the menu");
+            System.out.print(INPUT_PROMPT);
+            String subOption = input.nextLine().trim();
+            if (subOption.equalsIgnoreCase("BACK")) {
+                break;
+            }
+            try {
+                rat = RatType.values()[Integer.parseInt(subOption) - 1];
+            } catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
+                System.out.println("Invalid input, please try again.");
+            }
+        } while (rat == null);
+
+        return rat;
+    }
+
+
+    /**
+     * Helper method that get the RF Ports from user.
+     * Returns a list of RF Ports.
+     *
+     * @param input Scanner instance to get user input.
+     * @return The RfPorts that were selected by the user, as a List.
+     */
+    private static List<RfPort> chooseRfPorts(int noOfRfPorts, Scanner input) {
+        List<RfPort> ports = new ArrayList<>();
+        int count = 0;
+        int i = 0;
+        Set<Integer> choices = new HashSet<>();
+
+        System.out.printf("Please choose %d RF ports\n", noOfRfPorts);
+        for (RfPort currRfPort : RfPort.values()) {
+            System.out.println("	" + ++i + ".	" + currRfPort.getRfPort());
+        }
+        System.out.println("Enter 'Back' to go back to the menu");
+        System.out.print(INPUT_PROMPT);
+        do {
+            String subOption = input.next();
+            if (subOption.equalsIgnoreCase("BACK")) {
+                break;
+            }
+            try {
+                if (choices.contains(Integer.parseInt(subOption))) {
+                    System.out.println("This RF port has already been picked, please try again.\nEnter the next choice.");
+                    System.out.print(INPUT_PROMPT);
+                    continue;
+                }
+                choices.add(Integer.parseInt(subOption));
+                ports.add(RfPort.values()[Integer.parseInt(subOption) - 1]);
+                count++;
+            } catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
+                System.out.println("Invalid input, please try again.");
+                continue;
+            }
+            if (count != noOfRfPorts) {
+                System.out.println("Enter the next choice.");
+                System.out.print(INPUT_PROMPT);
+            }
+        } while (count < noOfRfPorts);
+        return ports;
+    }
+
+    /**
+     * Helper method that get the frequency band from user.
+     * Returns the frequency band user choose.
+     *
+     * @param ratType The RAT type of the frequency bands being requested.
+     * @param input   Scanner instance to get user input.
+     * @return The frequency band the user selected, as a FrequencyBand enum entry.
+     */
+    private static FrequencyBand chooseFreqBand(RatType ratType, Scanner input) {
+        FrequencyBand freqBand = null;
+        int i;
+        do {
+            i = 0;
+            System.out.println("Please choose the Carrier Frequency Band.");
+            if (!ratType.equals(RatType.LTE)) {
+                for (WcdmaFrequencyBand currWcdmaFreq : WcdmaFrequencyBand.values()) {
+                    System.out.println("	" + ++i + ".	" + currWcdmaFreq.getBand());
+                }
+            } else {
+                for (LteFrequencyBand currLteFreq : LteFrequencyBand.values()) {
+                    System.out.println("	" + ++i + ".	" + currLteFreq.getBand());
+                }
+            }
+            System.out.println("Enter 'Back' to go back to the menu");
+            System.out.print(INPUT_PROMPT);
+            String subOption = input.next();
+            if (subOption.equalsIgnoreCase("BACK")) {
+                break;
+            }
+            try {
+                if (ratType.equals(RatType.LTE)) {
+                    freqBand = LteFrequencyBand.values()[Integer.parseInt(subOption) - 1];
+                } else {
+                    freqBand = WcdmaFrequencyBand.values()[Integer.parseInt(subOption) - 1];
+                }
+            } catch (ArrayIndexOutOfBoundsException | NumberFormatException ex) {
+                System.out.println("Invalid input, please try again.");
+            }
+        } while (freqBand == null);
+
+        return freqBand;
+    }
 }

--- a/src/main/java/networkmanagementsystem/NetworkManagementSystem.java
+++ b/src/main/java/networkmanagementsystem/NetworkManagementSystem.java
@@ -2,17 +2,17 @@ package networkmanagementsystem;
 
 import common.*;
 import mediator.Mediator;
+import radiounit.AbstractManagedRadioUnitRegistry;
 import radiounit.ManagedRadioUnit;
 import radiounit.ManagedRadioUnitRegistry;
-import radiounit.AbstractManagedRadioUnitRegistry;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.util.*;
-import java.util.stream.Collectors;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static common.ProcedureOptions.*;
 
@@ -35,444 +35,418 @@ import static common.ProcedureOptions.*;
  * @author ebreojh
  */
 public class NetworkManagementSystem extends UnicastRemoteObject implements NetworkManagementSystemIf, PropertyChangeListener {
-	private static volatile NetworkManagementSystem UNIQUE_INSTANCE;
-	private final PropertyChangeSupport support;
-	private final HashMap<RatType, CommissionRadioUnit> commissioners;
-	private final HashMap<RatType, DecommissionRadioUnit> decommissioners;
-	private final AbstractManagedRadioUnitRegistry radioUnitRegistry;
-	private RatType currRatType;
+    private static volatile NetworkManagementSystem UNIQUE_INSTANCE;
+    private final PropertyChangeSupport support;
+    private final HashMap<RatType, CommissionRadioUnit> commissioners;
+    private final HashMap<RatType, DecommissionRadioUnit> decommissioners;
+    private final AbstractManagedRadioUnitRegistry radioUnitRegistry;
+    private RatType currRatType;
 
-	/**
-	 * Constructor for the NetworkManagementSystem class.
-	 * Required to be private to ensure the Singleton Pattern is followed.
-	 */
-	private NetworkManagementSystem() throws RemoteException {
-		commissioners = new HashMap<>();
-		commissioners.put(RatType.LTE, new CommissionLteRadioUnit());
-		commissioners.put(RatType.WCDMA, new CommissionWcdmaRadioUnit());
-		decommissioners = new HashMap<>();
-		decommissioners.put(RatType.LTE, new DecommissionLteRadioUnit());
-		decommissioners.put(RatType.WCDMA, new DecommissionWcdmaRadioUnit());
-		support = new PropertyChangeSupport(this);
-		radioUnitRegistry = ManagedRadioUnitRegistry.getInstance();
-	}
+    /**
+     * Constructor for the NetworkManagementSystem class.
+     * Required to be private to ensure the Singleton Pattern is followed.
+     */
+    private NetworkManagementSystem() throws RemoteException {
+        commissioners = new HashMap<>();
+        commissioners.put(RatType.LTE, new CommissionLteRadioUnit());
+        commissioners.put(RatType.WCDMA, new CommissionWcdmaRadioUnit());
+        decommissioners = new HashMap<>();
+        decommissioners.put(RatType.LTE, new DecommissionLteRadioUnit());
+        decommissioners.put(RatType.WCDMA, new DecommissionWcdmaRadioUnit());
+        support = new PropertyChangeSupport(this);
+        radioUnitRegistry = ManagedRadioUnitRegistry.getInstance();
+    }
 
-	/**
-	 * Get the unique NetworkManagementSystem instance.
-	 *
-	 * @return The Singleton instance of the NetworkManagementSystem class.
-	 */
-	public static NetworkManagementSystem getInstance() {
-		if (UNIQUE_INSTANCE == null) {
-			synchronized (Mediator.class) {
-				if (UNIQUE_INSTANCE == null) {
-					try {
-						UNIQUE_INSTANCE = new NetworkManagementSystem();
-					}
-					catch (RemoteException e)
-					{
-						System.out.println("Error connecting to remote server");
-						e.printStackTrace();
-						System.exit(0);
-					}
-				}
-			}
-		}
-		return UNIQUE_INSTANCE;
-	}
+    /**
+     * Get the unique NetworkManagementSystem instance.
+     *
+     * @return The Singleton instance of the NetworkManagementSystem class.
+     */
+    public static NetworkManagementSystem getInstance() {
+        if (UNIQUE_INSTANCE == null) {
+            synchronized (Mediator.class) {
+                if (UNIQUE_INSTANCE == null) {
+                    try {
+                        UNIQUE_INSTANCE = new NetworkManagementSystem();
+                    } catch (RemoteException e) {
+                        System.out.println("Error connecting to remote server");
+                        e.printStackTrace();
+                        System.exit(0);
+                    }
+                }
+            }
+        }
+        return UNIQUE_INSTANCE;
+    }
 
-	/**
-	 * Handle the request to commission a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that is being commissioned.
-	 */
-	@Override
-	public void commissionRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.FULL));
-		support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to commission a radio unit.
+     *
+     * @param ip The IP address of the radio unit that is being commissioned.
+     */
+    @Override
+    public void commissionRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.FULL));
+        support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to decommission a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that is being decommissioned.
-	 */
-	@Override
-	public void decommissionRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.FULL));
-		support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to decommission a radio unit.
+     *
+     * @param ip The IP address of the radio unit that is being decommissioned.
+     */
+    @Override
+    public void decommissionRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.FULL));
+        support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to add a radio unit.
-	 * This radio unit is not initially activated. Normally upon creation,
-	 * RUs should be commissioned via the commissionRu method.
-	 *
-	 * @param name    The name the radio unit can be identified by.
-	 * @param vendor  The vendor of the radio unit.
-	 * @param ratType The RAT type of the radio unit.
-	 */
-	@Override
-	public void addRadioUnit(String ip, String name, Vendor vendor, RatType ratType) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, name, vendor, ratType));
-		support.firePropertyChange(Procedure.CREATE.getDesc(), ProcedureOptions.RU, params);
-	}
+    /**
+     * Handle the request to add a radio unit.
+     * This radio unit is not initially activated. Normally upon creation,
+     * RUs should be commissioned via the commissionRu method.
+     *
+     * @param name    The name the radio unit can be identified by.
+     * @param vendor  The vendor of the radio unit.
+     * @param ratType The RAT type of the radio unit.
+     */
+    @Override
+    public void addRadioUnit(String ip, String name, Vendor vendor, RatType ratType) {
+        List<Object> params = new ArrayList<Object>(Arrays.asList(ip, name, vendor, ratType));
+        support.firePropertyChange(Procedure.CREATE.getDesc(), ProcedureOptions.RU, params);
+    }
 
-	/**
-	 * Handle the request to remove a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will be removed.
-	 */
-	@Override
-	public void removeRadioUnit(String ip) {
-		support.firePropertyChange(Procedure.DELETE.getDesc(), ProcedureOptions.RU, ip);
-	}
+    /**
+     * Handle the request to remove a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will be removed.
+     */
+    @Override
+    public void removeRadioUnit(String ip) {
+        support.firePropertyChange(Procedure.DELETE.getDesc(), ProcedureOptions.RU, ip);
+    }
 
-	/**
-	 * Handle the request to setup a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will be setup.
-	 */
-	@Override
-	public void setupRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, SETUP));
-		support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to setup a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will be setup.
+     */
+    @Override
+    public void setupRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, SETUP));
+        support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to release a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will be released.
-	 */
-	@Override
-	public void releaseRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.RELEASE));
-		support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to release a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will be released.
+     */
+    @Override
+    public void releaseRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.RELEASE));
+        support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to activate a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will be activated.
-	 */
-	@Override
-	public void activateRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ACTIVATE));
-		support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to activate a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will be activated.
+     */
+    @Override
+    public void activateRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ACTIVATE));
+        support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to deactivate a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will be deactivated.
-	 */
-	@Override
-	public void deactivateRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.DEACTIVATE));
-		support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to deactivate a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will be deactivated.
+     */
+    @Override
+    public void deactivateRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.DEACTIVATE));
+        support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to setup a carrier on an existing radio unit.
-	 *
-	 * @param ip                The IP address of the radio unit that will have a carrier added to it.
-	 * @param rfPorts           The RF ports for the carrier that is being created.
-	 * @param freq              The frequency band for the carrier that is being created.
-	 * @param transmittingPower The transmitting power for the carrier that is being created.
-	 */
-	@Override
-	public void setupCarrierOnRu(String ip, List<RfPort> rfPorts, FrequencyBand freq, Double transmittingPower) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, rfPorts, freq, transmittingPower));
-		support.firePropertyChange(Procedure.CREATE.getDesc(), ProcedureOptions.CARRIER, params);
-	}
+    /**
+     * Handle the request to setup a carrier on an existing radio unit.
+     *
+     * @param ip                The IP address of the radio unit that will have a carrier added to it.
+     * @param rfPorts           The RF ports for the carrier that is being created.
+     * @param freq              The frequency band for the carrier that is being created.
+     * @param transmittingPower The transmitting power for the carrier that is being created.
+     */
+    @Override
+    public void setupCarrierOnRu(String ip, List<RfPort> rfPorts, FrequencyBand freq, Double transmittingPower) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, rfPorts, freq, transmittingPower));
+        support.firePropertyChange(Procedure.CREATE.getDesc(), ProcedureOptions.CARRIER, params);
+    }
 
-	/**
-	 * Handle the request to modify a carrier on an existing radio unit.
-	 *
-	 * @param ip            The IP address of the radio unit that will have its carrier modified.
-	 * @param id            The ID number of the carrier that is being modified on that radio unit.
-	 * @param frequencyBand The frequency band that will be updated on the carrier.
-	 */
-	@Override
-	public void modifyCarrierOnRu(String ip, int id, FrequencyBand frequencyBand) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, id, frequencyBand));
-		support.firePropertyChange(Procedure.MODIFY.getDesc(), ProcedureOptions.CARRIER, params);
-	}
+    /**
+     * Handle the request to modify a carrier on an existing radio unit.
+     *
+     * @param ip            The IP address of the radio unit that will have its carrier modified.
+     * @param id            The ID number of the carrier that is being modified on that radio unit.
+     * @param frequencyBand The frequency band that will be updated on the carrier.
+     */
+    @Override
+    public void modifyCarrierOnRu(String ip, int id, FrequencyBand frequencyBand) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, id, frequencyBand));
+        support.firePropertyChange(Procedure.MODIFY.getDesc(), ProcedureOptions.CARRIER, params);
+    }
 
-	/**
-	 * Handle the request to remove a carrier from an existing radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will have its carrier removed.
-	 * @param id The ID number of the carrier that is being removed from that radio unit.
-	 */
-	@Override
-	public void removeCarrierOnRu(String ip, int id) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, id));
-		support.firePropertyChange(Procedure.DELETE.getDesc(), ProcedureOptions.CARRIER, params);
-	}
+    /**
+     * Handle the request to remove a carrier from an existing radio unit.
+     *
+     * @param ip The IP address of the radio unit that will have its carrier removed.
+     * @param id The ID number of the carrier that is being removed from that radio unit.
+     */
+    @Override
+    public void removeCarrierOnRu(String ip, int id) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, id));
+        support.firePropertyChange(Procedure.DELETE.getDesc(), ProcedureOptions.CARRIER, params);
+    }
 
-	/**
-	 * Handle the request to perform signal scaling on a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will perform signal scaling.
-	 */
-	@Override
-	public void signalScalingOnRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, SCALING));
-		support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to perform signal scaling on a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will perform signal scaling.
+     */
+    @Override
+    public void signalScalingOnRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, SCALING));
+        support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to perform a post activation on a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will perform post activation.
-	 */
-	@Override
-	public void postActivation(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.POST));
-		support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to perform a post activation on a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will perform post activation.
+     */
+    @Override
+    public void postActivation(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.POST));
+        support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to perform self diagnostics on a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will perform self diagnostics.
-	 */
-	@Override
-	public void performSelfDiagnostics(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.DIAGNOSTIC));
-		support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to perform self diagnostics on a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will perform self diagnostics.
+     */
+    @Override
+    public void performSelfDiagnostics(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.DIAGNOSTIC));
+        support.firePropertyChange(Procedure.COMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to remove all carriers from a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will have all of its carriers removed.
-	 */
-	@Override
-	public void removeAllCarriersOnRu(String ip) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.CARRIER));
-		support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
-	}
+    /**
+     * Handle the request to remove all carriers from a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will have all of its carriers removed.
+     */
+    @Override
+    public void removeAllCarriersOnRu(String ip) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, ProcedureOptions.CARRIER));
+        support.firePropertyChange(Procedure.DECOMMISSION.getDesc(), ProcedureOptions.RAT_TYPE, params);
+    }
 
-	/**
-	 * Handle the request to list all created radio units.
-	 */
-	@Override
-	public void listNetworkInventory() {
-		support.firePropertyChange(Procedure.LIST.getDesc(), ProcedureOptions.FULL, "");
-	}
+    /**
+     * Handle the request to list all created radio units.
+     */
+    @Override
+    public void listNetworkInventory() {
+        support.firePropertyChange(Procedure.LIST.getDesc(), ProcedureOptions.FULL, "");
+    }
 
-	/**
-	 * Handle the request to list all radio units that contain a certain parameter.
-	 *
-	 * @param param The parameter that will be used to query for radio units. Examples
-	 *              include a RatType, a RadioUnitState, a FrequencyBand, or a String name.
-	 */
-	@Override
-	public void listRuByParam(Object param) {
-		support.firePropertyChange(Procedure.LIST.getDesc(), ProcedureOptions.PARAM, param);
-	}
+    /**
+     * Handle the request to list all radio units that contain a certain parameter.
+     *
+     * @param param The parameter that will be used to query for radio units. Examples
+     *              include a RatType, a RadioUnitState, a FrequencyBand, or a String name.
+     */
+    @Override
+    public void listRuByParam(Object param) {
+        support.firePropertyChange(Procedure.LIST.getDesc(), ProcedureOptions.PARAM, param);
+    }
 
-	/**
-	 * Handle the request to list the details of a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will have its details listed.
-	 */
-	@Override
-	public void listRadioUnitDetails(String ip) {
-		support.firePropertyChange(Procedure.LIST.getDesc(), ProcedureOptions.RU, ip);
-	}
+    /**
+     * Handle the request to list the details of a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will have its details listed.
+     */
+    @Override
+    public void listRadioUnitDetails(String ip) {
+        support.firePropertyChange(Procedure.LIST.getDesc(), ProcedureOptions.RU, ip);
+    }
 
-	/**
-	 * Handle the request to set an alarm on a radio unit.
-	 *
-	 * @param ip    The IP address of the radio unit that will have an alarm raised.
-	 * @param alarm The alarm that will be raised on the radio unit.
-	 */
-	@Override
-	public void setAlarmOnRu(String ip, AlarmStatusLevel alarm) {
-		List<Object> params = new ArrayList<>(Arrays.asList(ip, alarm));
-		support.firePropertyChange(Procedure.CREATE.getDesc(), ProcedureOptions.ALARM, params);
-	}
+    /**
+     * Handle the request to set an alarm on a radio unit.
+     *
+     * @param ip    The IP address of the radio unit that will have an alarm raised.
+     * @param alarm The alarm that will be raised on the radio unit.
+     */
+    @Override
+    public void setAlarmOnRu(String ip, AlarmStatusLevel alarm) {
+        List<Object> params = new ArrayList<>(Arrays.asList(ip, alarm));
+        support.firePropertyChange(Procedure.CREATE.getDesc(), ProcedureOptions.ALARM, params);
+    }
 
-	/**
-	 * Handle the request to list all current network alarms.
-	 */
-	@Override
-	public String getNetworkAlarms() {
-		String result = "No radios are currently alarmed!";
-		
-		List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getAllRadios();
+    /**
+     * Handle the request to list all current network alarms.
+     */
+    @Override
+    public void getNetworkAlarms() {
+        List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getAllRadios();
 
-		radioUnits = radioUnits.stream()
-		.filter(ru -> ru.getAlarmStatus() != AlarmStatusLevel.NO_ALARM)
-		.collect(Collectors.toList());
-		
-		if (radioUnits.size() > 0)
-		{
-			for (ManagedRadioUnit ru : radioUnits)
-			{
-				result = ru.getIpAddress() + ": " + ru.getAlarmStatus() + "\n";
-			}
-		}
-		else
-		{
-			System.out.println("No radios are currently alarmed!");
-		}
-		
-		return result;
-	}
+        radioUnits = radioUnits.stream()
+                .filter(ru -> ru.getAlarmStatus() != AlarmStatusLevel.NO_ALARM)
+                .collect(Collectors.toList());
 
-	/**
-	 * Handle the request to acknowledge a raised alarm on a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that will have an alarm acknowledged.
-	 */
-	@Override
-	public boolean acknowledgeAlarm(String ip) {
-		ManagedRadioUnit radio = radioUnitRegistry.getByIpAddress(ip);
-		if (radio == null)
-		{
-			return false;
-		}
-		
-		radio.acknowledgeAlarm();
-		
-		return true;
-	}
+        if (radioUnits.size() > 0) {
+        	radioUnits.forEach(ru -> System.out.println(ru.getIpAddress() + ": " + ru.getAlarmStatus() + "\n"));
+        } else {
+            System.out.println("No Radio Units are currently alarmed within the system.");
+        }
+    }
 
-	/**
-	 * Get the map of all commissioner classes.
-	 *
-	 * @return A hashmap of all commissioner classes, keyed by RAT type.
-	 */
-	@Override
-	public HashMap<RatType, CommissionRadioUnit> getCommissioners() {
-		return commissioners;
-	}
+    /**
+     * Handle the request to acknowledge a raised alarm on a radio unit.
+     *
+     * @param ip The IP address of the radio unit that will have an alarm acknowledged.
+     */
+    @Override
+    public boolean acknowledgeAlarm(String ip) {
+        ManagedRadioUnit radio = radioUnitRegistry.getByIpAddress(ip);
+        if (radio == null) {
+            return false;
+        }
 
-	/**
-	 * Get the map of all decommissioner classes.
-	 *
-	 * @return A hashmap of all decommissioner classes, keyed by RAT type.
-	 */
-	@Override
-	public HashMap<RatType, DecommissionRadioUnit> getDecommissioners() {
-		return decommissioners;
-	}
+        radio.acknowledgeAlarm();
 
-	/**
-	 * Handle the request to get the RAT Type for a radio unit.
-	 *
-	 * @param ip The IP address of the radio unit that is having its RAT type request.
-	 * @return The RAT type of the radio unit that was requested.
-	 */
-	@Override
-	public RatType getRuRatType(String ip) {
-		support.firePropertyChange(Procedure.GET.getDesc(), ProcedureOptions.RAT_TYPE, ip);
-		return currRatType;
-	}
+        return true;
+    }
 
-	/**
-	 * Adds listeners to this class.
-	 *
-	 * @param pcl A property change listener.
-	 */
-	public void addPropertyChangeListener(PropertyChangeListener pcl) {
-		support.addPropertyChangeListener(pcl);
-	}
+    /**
+     * Get the map of all commissioner classes.
+     *
+     * @return A hashmap of all commissioner classes, keyed by RAT type.
+     */
+    @Override
+    public HashMap<RatType, CommissionRadioUnit> getCommissioners() {
+        return commissioners;
+    }
 
-	/**
-	 * This method gets called when a bound property is changed.
-	 *
-	 * @param evt A PropertyChangeEvent object describing the event source
-	 *            and the property that has changed.
-	 */
-	@Override
-	@SuppressWarnings("unchecked")
-	public void propertyChange(PropertyChangeEvent evt) {
-		// Determine which procedure we are working with.
-		Procedure procedure = null;
-		for (Procedure currProcedure : Procedure.values()) {
-			if (currProcedure.getDesc().equals(evt.getPropertyName())) {
-				procedure = currProcedure;
-			}
-		}
-		List<Object> params = new ArrayList<>();
-		// Only COMMISSION and DECOMMISSION need this list, while GET does not (hence the try/catch)
-		try {
-			params = ((ArrayList<Object>) evt.getNewValue());
-		} catch (ClassCastException ignored) {
-		}
-		switch (Objects.requireNonNull(procedure)) {
-		case COMMISSION:
-		{
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case FULL:
-			{
-				commissioners.get((RatType) params.get(1)).commissionRadioUnit((String) params.get(0));
-				break;
-			}
-			case SETUP:
-			{
-				commissioners.get((RatType) params.get(1)).setupRu((String) params.get(0));
-				break;
-			}
-			case ACTIVATE:
-			{
-				commissioners.get((RatType) params.get(1)).activateRu((String) params.get(0));
-				break;
-			}
-			case SCALING:
-			{
-				commissioners.get((RatType) params.get(1)).performSignalScaling((String) params.get(0));
-				break;
-			}
-			case POST:
-			{
-				commissioners.get((RatType) params.get(1)).postActivation((String) params.get(0));
-				break;
-			}
-			case DIAGNOSTIC:
-			{
-				commissioners.get((RatType) params.get(1)).performSelfDiagnotics((String) params.get(0));
-				break;
-			}
-			}
-			break;
-		}
-		case DECOMMISSION:
-		{
-			switch ((ProcedureOptions) evt.getOldValue()) {
-			case FULL:
-			{
-				decommissioners.get((RatType) params.get(1)).decommissionRadioUnit((String) params.get(0));
-				break;
-			}
-			case RELEASE:
-			{
-				decommissioners.get((RatType) params.get(1)).releaseRu((String) params.get(0));
-				break;
-			}
-			case DEACTIVATE:
-			{
-				decommissioners.get((RatType) params.get(1)).deactivateRu((String) params.get(0));
-				break;
-			}
-			case CARRIER:
-			{
-				decommissioners.get((RatType) params.get(1)).removeAllCarriersOnRu((String) params.get(0));
-				break;
-			}
-			}
-			break;
-		}
-		case GET:
-		{
-			currRatType = (RatType) evt.getNewValue();
-			break;
-		}
-		}
-	}
+    /**
+     * Get the map of all decommissioner classes.
+     *
+     * @return A hashmap of all decommissioner classes, keyed by RAT type.
+     */
+    @Override
+    public HashMap<RatType, DecommissionRadioUnit> getDecommissioners() {
+        return decommissioners;
+    }
+
+    /**
+     * Handle the request to get the RAT Type for a radio unit.
+     *
+     * @param ip The IP address of the radio unit that is having its RAT type request.
+     * @return The RAT type of the radio unit that was requested.
+     */
+    @Override
+    public synchronized RatType getRuRatType(String ip) {
+        support.firePropertyChange(Procedure.GET.getDesc(), ProcedureOptions.RAT_TYPE, ip);
+        return currRatType;
+    }
+
+    /**
+     * Adds listeners to this class.
+     *
+     * @param pcl A property change listener.
+     */
+    public void addPropertyChangeListener(PropertyChangeListener pcl) {
+        support.addPropertyChangeListener(pcl);
+    }
+
+    /**
+     * This method gets called when a bound property is changed.
+     *
+     * @param evt A PropertyChangeEvent object describing the event source
+     *            and the property that has changed.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void propertyChange(PropertyChangeEvent evt) {
+        // Determine which procedure we are working with.
+        Procedure procedure = null;
+        for (Procedure currProcedure : Procedure.values()) {
+            if (currProcedure.getDesc().equals(evt.getPropertyName())) {
+                procedure = currProcedure;
+            }
+        }
+        List<Object> params = new ArrayList<>();
+        // Only COMMISSION and DECOMMISSION need this list, while GET does not (hence the try/catch)
+        try {
+            params = ((ArrayList<Object>) evt.getNewValue());
+        } catch (ClassCastException ignored) {
+        }
+        switch (Objects.requireNonNull(procedure)) {
+            case COMMISSION: {
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case FULL: {
+                        commissioners.get((RatType) params.get(1)).commissionRadioUnit((String) params.get(0));
+                        break;
+                    }
+                    case SETUP: {
+                        commissioners.get((RatType) params.get(1)).setupRu((String) params.get(0));
+                        break;
+                    }
+                    case ACTIVATE: {
+                        commissioners.get((RatType) params.get(1)).activateRu((String) params.get(0));
+                        break;
+                    }
+                    case SCALING: {
+                        commissioners.get((RatType) params.get(1)).performSignalScaling((String) params.get(0));
+                        break;
+                    }
+                    case POST: {
+                        commissioners.get((RatType) params.get(1)).postActivation((String) params.get(0));
+                        break;
+                    }
+                    case DIAGNOSTIC: {
+                        commissioners.get((RatType) params.get(1)).performSelfDiagnotics((String) params.get(0));
+                        break;
+                    }
+                }
+                break;
+            }
+            case DECOMMISSION: {
+                switch ((ProcedureOptions) evt.getOldValue()) {
+                    case FULL: {
+                        decommissioners.get((RatType) params.get(1)).decommissionRadioUnit((String) params.get(0));
+                        break;
+                    }
+                    case RELEASE: {
+                        decommissioners.get((RatType) params.get(1)).releaseRu((String) params.get(0));
+                        break;
+                    }
+                    case DEACTIVATE: {
+                        decommissioners.get((RatType) params.get(1)).deactivateRu((String) params.get(0));
+                        break;
+                    }
+                    case CARRIER: {
+                        decommissioners.get((RatType) params.get(1)).removeAllCarriersOnRu((String) params.get(0));
+                        break;
+                    }
+                }
+                break;
+            }
+            case GET: {
+                currRatType = (RatType) evt.getNewValue();
+                break;
+            }
+        }
+    }
 }

--- a/src/main/java/networkmanagementsystem/NetworkManagementSystemIf.java
+++ b/src/main/java/networkmanagementsystem/NetworkManagementSystemIf.java
@@ -56,7 +56,7 @@ public interface NetworkManagementSystemIf extends Remote {
 
     void setAlarmOnRu(String ip, AlarmStatusLevel alarm) throws RemoteException;
 
-    String getNetworkAlarms() throws RemoteException;
+    void getNetworkAlarms() throws RemoteException;
 
     boolean acknowledgeAlarm(String ip) throws RemoteException;
 

--- a/src/main/java/radiounit/ConcreteRadioUnit.java
+++ b/src/main/java/radiounit/ConcreteRadioUnit.java
@@ -61,7 +61,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.setup();
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -73,7 +73,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.activate();
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -85,7 +85,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.deactivate();
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -97,7 +97,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.release();
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -108,10 +108,10 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 	public void signalScaling() {
 		try {
 			state.signalScaling();
+			signalScalingComplete = true; // TODO DAVID
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
-		signalScalingComplete = true; // TODO DAVID
 	}
 
 	/**
@@ -122,7 +122,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.setupCarrier(carrier);
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -134,7 +134,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.modifyCarrier(carrierId, freq);
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -146,7 +146,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.removeCarrier(carrierId);
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -158,7 +158,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.selfDiagnostics();
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -170,7 +170,7 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 		try {
 			state.removeAllCarriers();
 		} catch (IllegalStateTransitionException e) {
-			e.printStackTrace();
+			System.out.println(e.getMessage());
 		}
 	}
 
@@ -184,8 +184,12 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 
 	@Override
 	public void postActivation() {
-		System.out.println("Doing post activation");
-		postActivationComplete = true;
+		try {
+			state.postActivation();
+			postActivationComplete = true;
+		} catch (IllegalStateTransitionException e) {
+			System.out.println(e.getMessage());
+		}
 	}
 
 	@Override
@@ -245,7 +249,16 @@ public class ConcreteRadioUnit extends AbstractRadioUnit {
 
 	@Override
 	public String toString() {
-		return "Radio Unit Name: " + name + "\n" + "IP Address: " + ipAddress + "\n" + "Vendor and RAT type: " + vendor
-				+ " " + ratType;
+		StringBuffer details = new StringBuffer().append("Radio Unit Name: ").append(name).append("\nIP Address: ").append(ipAddress).append("\nVendor and RAT type: ").append(vendor.getLabel()).append(" ").append(ratType.getLabel()).append("\nState: ").append(state).append("\nAlarm: ").append(alarmStatus);
+		List<Carrier> carriers = getCarriers();
+		if (carriers.size() != 0) {
+			if (carriers.size() == 1) {
+				details.append("\nCarrier: ");
+			} else {
+				details.append("\nCarriers:\n");
+			}
+			carriers.forEach(carrier -> details.append(carrier.toString()));
+		}
+		return details.toString();
 	}
 }

--- a/src/main/java/radiounit/EricssonLteCommandExecutor.java
+++ b/src/main/java/radiounit/EricssonLteCommandExecutor.java
@@ -54,8 +54,14 @@ public class EricssonLteCommandExecutor implements RadioCommandExecutor {
 
 	@Override
 	public void setupCarrier(Carrier carrier) {
-		System.out.println("[EricssonLteCommandExecutor] setupCarrier: " + carrier);
+		System.out.println("[EricssonLteCommandExecutor] setupCarrier");
 		receiver.setupCarrierEricssonLte(carrier);
+	}
+
+	@Override
+	public void postActivation() {
+		System.out.println("[EricssonLteCommandExecutor] postActivation");
+		receiver.postActivationEricssonLte();
 	}
 
 	@Override

--- a/src/main/java/radiounit/EricssonLteRadioUnitReceiver.java
+++ b/src/main/java/radiounit/EricssonLteRadioUnitReceiver.java
@@ -50,7 +50,7 @@ public class EricssonLteRadioUnitReceiver implements RadioUnitReceiver {
 	}
 
 	public void setupCarrierEricssonLte(Carrier carrier) {
-		System.out.println("[EricssonLteRadioUnitReceiver] setupCarrierEricssonLte: " + carrier);
+		System.out.println("[EricssonLteRadioUnitReceiver] setupCarrierEricssonLte");
 		
 		// Validate carrier
 		FrequencyBand band = carrier.getFrequencyBand();
@@ -84,6 +84,10 @@ public class EricssonLteRadioUnitReceiver implements RadioUnitReceiver {
 
 	public void signalScalingEricssonLte() {
 		System.out.println("[EricssonLteRadioUnitReceiver] signalScalingEricssonLte");
+	}
+
+	public void postActivationEricssonLte() {
+		System.out.println("[EricssonLteRadioUnitReceiver] postActivationEricssonLte");
 	}
 
 	public void modifyCarrierEricssonLte(Integer carrierId, FrequencyBand frequencyBand) {
@@ -126,15 +130,7 @@ public class EricssonLteRadioUnitReceiver implements RadioUnitReceiver {
 
 	public List<Carrier> getCarriers() {
 		System.out.println("[EricssonLteRadioUnitReceiver] getCarriers");
-		
-		List<Carrier> allCarriers = new ArrayList<>(this.carriers.values());
-		
-		for (Carrier c : allCarriers)
-		{
-			System.out.println("Carrier: " + c);
-		}
-		
-		return allCarriers;
+		return new ArrayList<>(this.carriers.values());
 	}
 
 }

--- a/src/main/java/radiounit/EricssonLteRadioUnitReceiverFactory.java
+++ b/src/main/java/radiounit/EricssonLteRadioUnitReceiverFactory.java
@@ -21,7 +21,7 @@ public class EricssonLteRadioUnitReceiverFactory implements RadioUnitReceiverFac
 	 * Static method for retrieving the singleton object.
 	 * The synchronized keyword ensures that the block it surrounds is only accessed by a single thread at a time 
 	 * 
-	 * Forcing every thread to wait it's turn before it can enter the block via synchronize can add additional
+	 * Forcing every thread to wait its turn before it can enter the block via synchronize can add additional
 	 * 	overhead.
 	 * 
 	 * This method employs "double-checked locking" of the UNIQUE_INSTANCE variable, so that we only synchronize on the first time

--- a/src/main/java/radiounit/EricssonWcdmaCommandExecutor.java
+++ b/src/main/java/radiounit/EricssonWcdmaCommandExecutor.java
@@ -46,7 +46,7 @@ public class EricssonWcdmaCommandExecutor implements RadioCommandExecutor {
 
 	@Override
 	public void setupCarrier(Carrier carrier) {
-		System.out.println("[EricssonWcdmaCommandExecutor] setupCarrier: " + carrier);
+		System.out.println("[EricssonWcdmaCommandExecutor] setupCarrier");
 		receiver.setupCarrierEricssonWcdma(carrier);
 	}
 
@@ -78,6 +78,12 @@ public class EricssonWcdmaCommandExecutor implements RadioCommandExecutor {
 	public void removeAllCarriers() {
 		System.out.println("[EricssonWcdmaCommandExecutor] removeAllCarriers");
 		receiver.removeAllCarriersEricssonWcdma();
+	}
+
+	@Override
+	public void postActivation() {
+		System.out.println("[EricssonWcdmaCommandExecutor] postActivation");
+		receiver.postActivationEricssonWcdma();
 	}
 
 	@Override

--- a/src/main/java/radiounit/EricssonWcdmaRadioUnitReceiver.java
+++ b/src/main/java/radiounit/EricssonWcdmaRadioUnitReceiver.java
@@ -49,7 +49,7 @@ public class EricssonWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 	}
 
 	public void setupCarrierEricssonWcdma(Carrier carrier) {
-		System.out.println("[EricssonWcdmaRadioUnitReceiver] setupCarrierEricssonWcdma: " + carrier);
+		System.out.println("[EricssonWcdmaRadioUnitReceiver] setupCarrierEricssonWcdma");
 
 		// check if carrier is a WCDMA carrier
 		boolean isWcdma = false;
@@ -78,6 +78,10 @@ public class EricssonWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 
 	public void signalScalingEricssonWcdma() {
 		System.out.println("[EricssonWcdmaRadioUnitReceiver] signalScalingEricssonWcdma");
+	}
+
+	public void postActivationEricssonWcdma() {
+		System.out.println("[EricssonWcdmaRadioUnitReceiver] postActivationEricssonWcdma");
 	}
 
 	public void modifyCarrierEricssonWcdma(Integer carrierId, FrequencyBand frequencyBand) {
@@ -119,14 +123,6 @@ public class EricssonWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 
 	public List<Carrier> getCarriers() {
 		System.out.println("[EricssonWcdmaRadioUnitReceiver] getCarriers");
-		
-		List<Carrier> allCarriers = new ArrayList<>(this.carriers.values());
-		
-		for (Carrier c : allCarriers)
-		{
-			System.out.println("Carrier: " + c);
-		}
-		
-		return allCarriers;
+		return new ArrayList<>(this.carriers.values());
 	}
 }

--- a/src/main/java/radiounit/ManagedRadioUnitRegistry.java
+++ b/src/main/java/radiounit/ManagedRadioUnitRegistry.java
@@ -121,7 +121,15 @@ public class ManagedRadioUnitRegistry extends AbstractManagedRadioUnitRegistry {
 
 	@Override
 	public void removeRadioUnit(String ip) {
-		radioUnits.removeIf(ru -> (ru.getIpAddress().equals(ip)));
+		ManagedRadioUnit removedDetails = getByIpAddress(ip);
+		boolean removed = radioUnits.removeIf(ru -> (ru.getIpAddress().equals(ip)));
+		if (removed) {
+			System.out.printf("[ManagedRadioUnitRegistry] Successfully removed a Radio Unit.\n" +
+					"Here are the details of the Radio Unit that was removed:\n");
+			System.out.println(removedDetails.toString());
+		} else {
+			System.out.printf("[ManagedRadioUnitRegistry] Failed to removed Radio Unit with the IP address \"%s\" " +
+					"as it was not found in the system.\n ", ip);
+		}
 	}
-
 }

--- a/src/main/java/radiounit/NokiaLteCommandExecutor.java
+++ b/src/main/java/radiounit/NokiaLteCommandExecutor.java
@@ -46,7 +46,7 @@ public class NokiaLteCommandExecutor implements RadioCommandExecutor {
 
 	@Override
 	public void setupCarrier(Carrier carrier) {
-		System.out.println("[NokiaLteCommandExecutor] setupCarrier: " + carrier);
+		System.out.println("[NokiaLteCommandExecutor] setupCarrier");
 		receiver.setupCarrierNokiaLte(carrier);
 	}
 
@@ -72,6 +72,12 @@ public class NokiaLteCommandExecutor implements RadioCommandExecutor {
 	public void selfDiagnostics() {
 		System.out.println("[NokiaLteCommandExecutor] selfDiagnostics");
 		receiver.selfDiagnosticsNokiaLte();
+	}
+
+	@Override
+	public void postActivation() {
+		System.out.println("[NokiaLteCommandExecutor] postActivation");
+		receiver.postActivationNokiaLte();
 	}
 
 	@Override

--- a/src/main/java/radiounit/NokiaLteRadioUnitReceiver.java
+++ b/src/main/java/radiounit/NokiaLteRadioUnitReceiver.java
@@ -49,7 +49,7 @@ public class NokiaLteRadioUnitReceiver implements RadioUnitReceiver {
 	}
 
 	public void setupCarrierNokiaLte(Carrier carrier) {
-		System.out.println("[NokiaLteRadioUnitReceiver] setupCarrierNokiaLte: " + carrier);
+		System.out.println("[NokiaLteRadioUnitReceiver] setupCarrierNokiaLte");
 
 		// check if carrier is a LTE carrier
 		boolean isLte = false;
@@ -110,6 +110,10 @@ public class NokiaLteRadioUnitReceiver implements RadioUnitReceiver {
 		System.out.println("[NokiaLteRadioUnitReceiver] selfDiagnosticsNokiaLte");
 	}
 
+	public void postActivationNokiaLte() {
+		System.out.println("[NokiaLteRadioUnitReceiver] postActivationNokiaLte");
+	}
+
 	public void removeAllCarriersNokiaLte() {
 		System.out.println("[NokiaLteRadioUnitReceiver] removeAllCarriersNokiaLte");
 
@@ -118,14 +122,6 @@ public class NokiaLteRadioUnitReceiver implements RadioUnitReceiver {
 
 	public List<Carrier> getCarriers() {
 		System.out.println("[NokiaLteRadioUnitReceiver] getCarriers");
-		
-		List<Carrier> allCarriers = new ArrayList<>(this.carriers.values());
-		
-		for (Carrier c : allCarriers)
-		{
-			System.out.println("Carrier: " + c);
-		}
-		
-		return allCarriers;
+		return new ArrayList<>(this.carriers.values());
 	}
 }

--- a/src/main/java/radiounit/NokiaWcdmaCommandExecutor.java
+++ b/src/main/java/radiounit/NokiaWcdmaCommandExecutor.java
@@ -46,7 +46,7 @@ public class NokiaWcdmaCommandExecutor implements RadioCommandExecutor {
 
 	@Override
 	public void setupCarrier(Carrier carrier) {
-		System.out.println("[NokiaWcdmaCommandExecutor] setupCarrier: " + carrier);
+		System.out.println("[NokiaWcdmaCommandExecutor] setupCarrier");
 		receiver.setupCarrierNokiaWcdma(carrier);
 	}
 
@@ -78,6 +78,12 @@ public class NokiaWcdmaCommandExecutor implements RadioCommandExecutor {
 	public void removeAllCarriers() {
 		System.out.println("[NokiaWcdmaCommandExecutor] removeAllCarriers");
 		receiver.removeAllCarriersNokiaWcdma();
+	}
+
+	@Override
+	public void postActivation() {
+		System.out.println("[NokiaWcdmaCommandExecutor] postActivation");
+		receiver.postActivationNokiaWcdma();
 	}
 
 	@Override

--- a/src/main/java/radiounit/NokiaWcdmaRadioUnitReceiver.java
+++ b/src/main/java/radiounit/NokiaWcdmaRadioUnitReceiver.java
@@ -19,10 +19,10 @@ public class NokiaWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 
 	/*
 	 * The list of carriers is an important part of the radio
-	 * 
+	 *
 	 * The "volatile" keyword ensures that this resource is not cached, and is
 	 * retrieved directly from memory every time it is accessed.
-	 * 
+	 *
 	 * The three "-Internal" methods below are all synchronized and have exclusive
 	 * access to this resource.
 	 */
@@ -49,7 +49,7 @@ public class NokiaWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 	}
 
 	public void setupCarrierNokiaWcdma(Carrier carrier) {
-		System.out.println("[NokiaWcdmaRadioUnitReceiver] setupCarrierNokiaWcdma: " + carrier);
+		System.out.println("[NokiaWcdmaRadioUnitReceiver] setupCarrierNokiaWcdma");
 
 		// check if carrier is a WCDMA carrier
 		boolean isWcdma = false;
@@ -65,7 +65,7 @@ public class NokiaWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 			System.err.println("Cannot add non-WCDMA carrier to WCDMA radio!");
 			return;
 		}
-		
+
 		int carrierId = carrier.getCarrierId();
 
 		if (this.carriers.containsKey(carrierId)) {
@@ -80,6 +80,10 @@ public class NokiaWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 		System.out.println("[NokiaWcdmaRadioUnitReceiver] signalScalingNokiaWcdma");
 	}
 
+	public void postActivationNokiaWcdma() {
+		System.out.println("[NokiaWcdmaRadioUnitReceiver] postActivationNokiaWcdma");
+	}
+
 	public void modifyCarrierNokiaWcdma(Integer carrierId, FrequencyBand frequencyBand) {
 		System.out.println(
 				"[NokiaWcdmaRadioUnitReceiver] modifyCarrierNokiaWcdma: " + carrierId + ", " + frequencyBand.getBand());
@@ -90,19 +94,19 @@ public class NokiaWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 		}
 
 		Carrier existingCarrier = this.carriers.get(carrierId);
-		
+
 		Objects.requireNonNull(existingCarrier).setFrequencyBand(frequencyBand);
-		
+
 		this.carriers.replace(carrierId, existingCarrier);
 	}
 
 	public void removeCarrierNokiaWcdma(Integer carrierId) {
 		System.out.println("[NokiaWcdmaRadioUnitReceiver] removeCarrierNokiaWcdma: " + carrierId);
-		
+
 		if (!this.carriers.containsKey(carrierId)) {
 			System.err.println("NokiaWcdmaRadioUnitReceiver[] Invalid carrierId - cannot remove carrier");
 		}
-		
+
 		this.carriers.remove(carrierId);
 	}
 
@@ -117,14 +121,6 @@ public class NokiaWcdmaRadioUnitReceiver implements RadioUnitReceiver {
 
 	public List<Carrier> getCarriers() {
 		System.out.println("[NokiaWcdmaRadioUnitReceiver] getCarriers");
-		
-		List<Carrier> allCarriers = new ArrayList<>(this.carriers.values());
-		
-		for (Carrier c : allCarriers)
-		{
-			System.out.println("Carrier: " + c);
-		}
-		
-		return allCarriers;
+		return new ArrayList<>(this.carriers.values());
 	}
 }

--- a/src/main/java/radiounit/RadioCommandExecutor.java
+++ b/src/main/java/radiounit/RadioCommandExecutor.java
@@ -32,6 +32,8 @@ public interface RadioCommandExecutor {
 
 	void removeAllCarriers();
 
+	void postActivation();
+
 	List<Carrier> getCarriers();
 
 }

--- a/src/main/java/radiounit/RadioUnitReceiver.java
+++ b/src/main/java/radiounit/RadioUnitReceiver.java
@@ -9,6 +9,7 @@ import java.util.List;
  * @author esiumat
  *
  */
+@FunctionalInterface
 public interface RadioUnitReceiver {
 
 	List<Carrier> getCarriers();

--- a/src/main/java/radiounit/RadioUnitState.java
+++ b/src/main/java/radiounit/RadioUnitState.java
@@ -30,6 +30,8 @@ public interface RadioUnitState {
 	void selfDiagnostics() throws IllegalStateTransitionException;
 	
 	void removeAllCarriers() throws IllegalStateTransitionException;
+
+	void postActivation() throws IllegalStateTransitionException;
 	
 	RadioUnitStateE getRuStateE();
 	

--- a/src/main/java/radiounit/radiostate/ActivatedState.java
+++ b/src/main/java/radiounit/radiostate/ActivatedState.java
@@ -52,8 +52,7 @@ public class ActivatedState implements RadioUnitState {
 
 	@Override
 	public void setupCarrier(Carrier carrier) throws IllegalStateTransitionException {
-		System.out.printf("Setting up carrier (%s) on Radio Unit.%n", carrier);
-		
+		System.out.printf("Setting up carrier on Radio Unit.%n");
 		this.radio.getCommandExecutor().setupCarrier(carrier);
 	}
 
@@ -89,7 +88,14 @@ public class ActivatedState implements RadioUnitState {
 		throw new IllegalStateTransitionException(
 				String.format("Cannot remove all carriers from Radio Unit while it is in the %s state.", this.name));
 	}
-	
+
+	@Override
+	public void postActivation() throws IllegalStateTransitionException {
+		System.out.println("Performing post activation on Radio Unit.");
+
+		this.radio.getCommandExecutor().postActivation();
+	}
+
 	@Override
 	public RadioUnitStateE getRuStateE() {
 		return name;

--- a/src/main/java/radiounit/radiostate/DeactivatedState.java
+++ b/src/main/java/radiounit/radiostate/DeactivatedState.java
@@ -90,7 +90,13 @@ public class DeactivatedState implements RadioUnitState {
 		
 		this.radio.getCommandExecutor().removeAllCarriers();
 	}
-	
+
+	@Override
+	public void postActivation() throws IllegalStateTransitionException {
+		throw new IllegalStateTransitionException(
+				String.format("Cannot perform self diagnostics on Radio Unit while it is in the %s state.", this.name));
+	}
+
 	@Override
 	public RadioUnitStateE getRuStateE() {
 		return name;

--- a/src/main/java/radiounit/radiostate/IdleState.java
+++ b/src/main/java/radiounit/radiostate/IdleState.java
@@ -55,7 +55,7 @@ public class IdleState implements RadioUnitState {
 	@Override
 	public void signalScaling() throws IllegalStateTransitionException {
 		throw new IllegalStateTransitionException(
-				String.format("Cannot perfrom signal scaling on Radio Unit while it is in the %s state.", this.name));
+				String.format("Cannot perform signal scaling on Radio Unit while it is in the %s state.", this.name));
 	}
 
 	@Override
@@ -81,7 +81,13 @@ public class IdleState implements RadioUnitState {
 		throw new IllegalStateTransitionException(
 				String.format("Cannot remove all carriers from Radio Unit while it is in the %s state.", this.name));
 	}
-	
+
+	@Override
+	public void postActivation() throws IllegalStateTransitionException {
+		throw new IllegalStateTransitionException(
+				String.format("Cannot perform post activation on Radio Unit while it is in the %s state.", this.name));
+	}
+
 	@Override
 	public RadioUnitStateE getRuStateE() {
 		return name;


### PR DESCRIPTION
- Made the UI look nicer (although newline spacing isn't consistent, there's now an input prompt and I cleaned up the sentence structure throughout).
- Removed some unnecessary input from the radiounit classes (specifically, when setting up a carrier on an RU, it would print out the carrier it was setting up 3 times between all of the classes. It now prints it out exactly 0 times since we were already printing out the final results of a carrier after we had made it).
- Modified the IllegalStateTransitionExceptions so that the stack trace isn't printed to the console.
- States work (hooray).
- Added postActivation() to the states and necessary executors/receivers since it was missing for some reason.
- Radio units will now print out their list of carriers (if they have any setup).
- You can no longer select the same RF port when setting up a carrier.
- Added some missing back options for various choices throughout the UI.
- Whenever an operation is successful or useful data is displayed, you will now have to hit enter before returning to the main menu for both the NetworkManagementClient and AlarmMonitoringClient. This way, you can read the output of the operation before the entire menu prints, causing you to have to scroll up to see what was done.
- Added some dumb headers to both the NetworkManagementClient and AlarmMonitoringClient because I thought it would look nice.
- I couldn't be bothered to verify the states for when you can and can't perform an operation, but assuming what was already there matches the exam outline we are good (for example we can't set up a carrier if the RU is idle/deactivated, we can't remove carriers in the RU is activated, etc.)
- Fixed the formatting in some classes (the indentation somehow got messed up).
- Made the failure messages a bit more consistent and descriptive in the Mediator class.
- I think I changed the return type for one of the alarm-related methods at some point.
- Made getRuRatType() in the NetworkManagementSystem synchronized since there's a write operation involved and it could have led to nasty race conditions.
- Really thought about implementing the dumb way I'm using in getRuRatType() to get data back for the AlarmMonitoringSystem but decided I didn't care enough to completely decouple the RadioUnitRegistry from the NetworkManagementSystem. So now both ways exist happily in our code.
- From what I've tried (and trust me I tried a lot), I can no longer break the program or get it to behave incorrectly.
- I'm very tired of looking at this code but if issues pop up I'll fix them.