### PR TITLE
Bugfix for error where there would be a duplicated message for option 16

### DIFF
--- a/src/main/java/mediator/Mediator.java
+++ b/src/main/java/mediator/Mediator.java
@@ -66,7 +66,6 @@ public class Mediator implements PropertyChangeListener, MediatorIf {
 	 */
 	private void printRegisteredRadioUnits() {
 		List<ManagedRadioUnit> radioUnits = radioUnitRegistry.getAllRadios();
-		radioUnits.forEach(System.out::println);
 		if (radioUnits.size() == 0) {
 			System.out.println("[ERROR] No RUs have been registered with the system.");
 		} else {


### PR DESCRIPTION
Issue observed:

- When option 16 would be selected, all radios would print twice. 
- For example, if we had a Ericsson LTE and Nokia WCDMA, it would print:

Radio Unit Name: 1
IP Address: 206.84.107.172
Vendor and RAT type: ERICSSON LTE
Radio Unit Name: 2
IP Address: 21.38.191.77
Vendor and RAT type: NOKIA WCDMA
Radio Unit Name: 1
IP Address: 206.84.107.172
Vendor and RAT type: ERICSSON LTE
Radio Unit Name: 2
IP Address: 21.38.191.77
Vendor and RAT type: NOKIA WCDMA

Issue determined: 

- In the mediator "printRegisteredRadioUnits" method, there seems to be a duplicated print method. This method seems only to be called when option 16 is chosen. Does not appear to affect other "List RUs b y ___" methods. 